### PR TITLE
Align and animate message box

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -14,19 +14,32 @@ html, body {
  @keyframes swim {
    to { transform: translateX(-50%); }
  }
- #message {
-   display: none;
-   position: absolute;
-   left: 50%;
-   bottom: 0;
-   transform: translateX(-50%);
-   width: 100%;
-   max-width: 500px;
-   background: #fff;
-   box-sizing: border-box;
-   padding: 24px;
-   border-radius: 16px 16px 0 0;
- }
+#message {
+  position: absolute;
+  left: 50%;
+  bottom: 0;
+  transform: translate(-50%, 100%);
+  width: 100%;
+  max-width: 500px;
+  background: #fff;
+  box-sizing: border-box;
+  padding: 24px;
+  border-radius: 16px 16px 0 0;
+  text-align: left;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 16px;
+  opacity: 0;
+  pointer-events: none;
+  transition: transform 0.3s ease-out, opacity 0.3s ease-out;
+}
+
+#message.show {
+  transform: translate(-50%, 0);
+  opacity: 1;
+  pointer-events: auto;
+}
  #message p {
    font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
    font-size: 24px;
@@ -35,9 +48,6 @@ html, body {
  }
 #message img {
   width: 72px;
-  display: block;
-  margin-left: auto;
-  margin-right: auto;
 }
  #message button {
    width: 100%;
@@ -49,9 +59,3 @@ html, body {
    font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
    font-size: 18px;
  }
-#message > * {
-  margin: 0 0 16px;
-}
-#message > *:last-child {
-  margin-bottom: 0;
-}

--- a/js/script.js
+++ b/js/script.js
@@ -1,3 +1,6 @@
 document.getElementById('shellfin').addEventListener('animationend', function() {
-  document.getElementById('message').style.display = 'block';
+  const message = document.getElementById('message');
+  requestAnimationFrame(() => {
+    message.classList.add('show');
+  });
 });


### PR DESCRIPTION
## Summary
- Use opacity and transform transitions so the message box flex container smoothly slides up.
- Simplify JavaScript to only add the show class after the shellfin animation finishes.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68afaf3c11588329b6a917f1a8104639