### PR TITLE
Smooth message box slide and remove bottom gap

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,7 +1,8 @@
 html, body {
     width: 100%;
     height: 100%;
-   background: url('../images/background.png') no-repeat center/cover;
+    margin: 0;
+    background: url('../images/background.png') no-repeat center/cover;
  }
  #shellfin {
    position: absolute;
@@ -14,8 +15,7 @@ html, body {
  @keyframes swim {
    to { transform: translateX(-50%); }
  }
- #message {
-   display: none;
+#message {
    position: absolute;
    left: 50%;
    bottom: 0;
@@ -27,13 +27,13 @@ html, body {
    padding: 24px;
    border-radius: 16px 16px 0 0;
    text-align: left;
-   transition: transform 0.3s ease-out;
+   transition: transform 0.5s ease-out;
+   display: flex;
+   flex-direction: column;
+   align-items: flex-start;
  }
 
 #message.show {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
   transform: translate(-50%, 0);
 }
  #message p {

--- a/js/script.js
+++ b/js/script.js
@@ -1,7 +1,3 @@
-document.getElementById('shellfin').addEventListener('animationend', function() {
-  const message = document.getElementById('message');
-  message.style.display = 'flex';
-  requestAnimationFrame(() => {
-    message.classList.add('show');
-  });
+document.getElementById('shellfin').addEventListener('animationend', () => {
+  document.getElementById('message').classList.add('show');
 });


### PR DESCRIPTION
## Summary
- Add margin reset and smooth transition for the message box
- Simplify script to trigger slide animation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68afb2918e488329859995286dbd20bc