### PR TITLE
Add enemy encounter scene to tutorial

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -4,11 +4,13 @@ html, body {
     margin: 0;
     background: url('../images/background.png') no-repeat center/cover;
  }
-#shellfin {
+#shellfin,
+#enemy {
   position: absolute;
   left: 50%;
   bottom: 30%;
   width: 300px;
+  max-width: 80vw;
   transform: translateX(100vw);
   animation: swim 2s forwards;
 }
@@ -18,12 +20,6 @@ html, body {
 }
 
 #enemy {
-  position: absolute;
-  left: 50%;
-  bottom: 30%;
-  width: 300px;
-  transform: translateX(100vw);
-  animation: swim 2s forwards;
   display: none;
 }
 @keyframes swim {

--- a/css/style.css
+++ b/css/style.css
@@ -4,17 +4,46 @@ html, body {
     margin: 0;
     background: url('../images/background.png') no-repeat center/cover;
  }
- #shellfin {
-   position: absolute;
-   left: 50%;
-   bottom: 30%;
-   width: 300px;
-   transform: translateX(100vw);
-   animation: swim 2s forwards;
- }
- @keyframes swim {
-   to { transform: translateX(-50%); }
- }
+#shellfin {
+  position: absolute;
+  left: 50%;
+  bottom: 30%;
+  width: 300px;
+  transform: translateX(100vw);
+  animation: swim 2s forwards;
+}
+
+#shellfin.pop {
+  animation: bubble-pop 0.5s forwards;
+}
+
+#enemy {
+  position: absolute;
+  left: 50%;
+  bottom: 30%;
+  width: 300px;
+  transform: translateX(100vw);
+  animation: swim 2s forwards;
+  display: none;
+}
+@keyframes swim {
+  to { transform: translateX(-50%); }
+}
+
+@keyframes bubble-pop {
+  0% {
+    transform: translateX(-50%) scale(1);
+    opacity: 1;
+  }
+  80% {
+    transform: translateX(-50%) scale(1.2);
+    opacity: 1;
+  }
+  100% {
+    transform: translateX(-50%) scale(0);
+    opacity: 0;
+  }
+}
 #message {
    position: absolute;
    left: 50%;

--- a/html/index.html
+++ b/html/index.html
@@ -10,9 +10,10 @@
    <link rel="stylesheet" href="../css/style.css" />
  </head>
  <body>
-   <div id="game">
-      <img id="shellfin" src="../images/shellfin.png" alt="Shellfin" />
-      <div id="message">
+  <div id="game">
+     <img id="shellfin" src="../images/shellfin.png" alt="Shellfin" />
+     <img id="enemy" src="../images/enemy.png" alt="Enemy" />
+     <div id="message">
         <img src="../images/shellfin_message.png" alt="Shellfin avatar" />
         <p>Hi! I’m Shellfin – half turtle, half manta ray. Monsters have taken over my reef, and I need your help!</p>
         <button>Continue</button>

--- a/js/script.js
+++ b/js/script.js
@@ -1,3 +1,33 @@
-document.getElementById('shellfin').addEventListener('animationend', () => {
-  document.getElementById('message').classList.add('show');
+document.addEventListener('DOMContentLoaded', () => {
+  const shellfin = document.getElementById('shellfin');
+  const enemy = document.getElementById('enemy');
+  const message = document.getElementById('message');
+  const messageText = message.querySelector('p');
+  const button = message.querySelector('button');
+
+  shellfin.addEventListener('animationend', (e) => {
+    if (e.animationName === 'swim') {
+      message.classList.add('show');
+    }
+  });
+
+  function startBattle() {
+    message.classList.remove('show');
+    button.removeEventListener('click', startBattle);
+    shellfin.classList.add('pop');
+    shellfin.addEventListener('animationend', function handlePop(e) {
+      if (e.animationName === 'bubble-pop') {
+        shellfin.style.display = 'none';
+        enemy.style.display = 'block';
+        shellfin.removeEventListener('animationend', handlePop);
+      }
+    });
+  }
+
+  button.addEventListener('click', startBattle);
+
+  enemy.addEventListener('animationend', () => {
+    messageText.textContent = "Monster spotted! It’s battle time. My attacks are powered by learning. The more you know, the tougher I become!";
+    message.classList.add('show');
+  });
 });

--- a/js/script.js
+++ b/js/script.js
@@ -24,10 +24,27 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
 
-  button.addEventListener('click', startBattle);
+  function resetScene() {
+    shellfin.style.display = 'block';
+    enemy.style.display = 'none';
+    shellfin.classList.remove('pop');
+    message.classList.remove('show');
+    messageText.textContent = "Hi! I’m Shellfin – half turtle, half manta ray. Monsters have taken over my reef, and I need your help!";
+    button.removeEventListener('click', startBattle);
+    button.addEventListener('click', startBattle);
+    shellfin.style.animation = 'none';
+    enemy.style.animation = 'none';
+    void shellfin.offsetWidth;
+    void enemy.offsetWidth;
+    shellfin.style.animation = '';
+    enemy.style.animation = '';
+  }
 
   enemy.addEventListener('animationend', () => {
     messageText.textContent = "Monster spotted! It’s battle time. My attacks are powered by learning. The more you know, the tougher I become!";
     message.classList.add('show');
   });
+
+  resetScene();
+  window.addEventListener('pageshow', resetScene);
 });


### PR DESCRIPTION
## Summary
- Show an enemy character after the intro, using the same slide-in animation.
- Display a second message prompting battle with learning-powered attacks.
- Pop Shellfin like a bubble as he disappears before the enemy arrives.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68afb549a3388329852320c380357ed7