### PR TITLE
Add battle walkthrough sequence with sliding characters

### DIFF
--- a/css/battle.css
+++ b/css/battle.css
@@ -1,0 +1,42 @@
+html, body {
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  overflow: hidden;
+  background: url('../images/background.png') no-repeat center/cover;
+}
+
+#battle {
+  position: relative;
+  width: 100%;
+  height: 100%;
+}
+
+#battle-monster,
+#battle-shellfin {
+  position: absolute;
+  width: 300px;
+  max-width: 80vw;
+}
+
+#battle-monster {
+  top: 10%;
+  left: 100%;
+  animation: monster-slide 3s linear forwards;
+}
+
+#battle-shellfin {
+  bottom: 10%;
+  left: -300px;
+  animation: shellfin-slide 3s linear forwards;
+}
+
+@keyframes monster-slide {
+  from { left: 100%; }
+  to { left: -300px; }
+}
+
+@keyframes shellfin-slide {
+  from { left: -300px; }
+  to { left: 100%; }
+}

--- a/html/battle.html
+++ b/html/battle.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+  <meta name="theme-color" content="transparent" />
+  <meta name="apple-mobile-web-app-capable" content="yes" />
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+  <title>Battle</title>
+  <link rel="stylesheet" href="../css/battle.css" />
+</head>
+<body>
+  <div id="battle">
+    <img id="battle-monster" src="../images/monster_battle.png" alt="Monster" />
+    <img id="battle-shellfin" src="../images/shellfin_battle.png" alt="Shellfin" />
+  </div>
+</body>
+</html>

--- a/js/script.js
+++ b/js/script.js
@@ -13,7 +13,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function startBattle() {
     message.classList.remove('show');
-    button.removeEventListener('click', startBattle);
+    button.onclick = null;
     shellfin.classList.add('pop');
     shellfin.addEventListener('animationend', function handlePop(e) {
       if (e.animationName === 'bubble-pop') {
@@ -30,8 +30,7 @@ document.addEventListener('DOMContentLoaded', () => {
     shellfin.classList.remove('pop');
     message.classList.remove('show');
     messageText.textContent = "Hi! I’m Shellfin – half turtle, half manta ray. Monsters have taken over my reef, and I need your help!";
-    button.removeEventListener('click', startBattle);
-    button.addEventListener('click', startBattle);
+    button.onclick = startBattle;
     shellfin.style.animation = 'none';
     enemy.style.animation = 'none';
     void shellfin.offsetWidth;
@@ -43,8 +42,11 @@ document.addEventListener('DOMContentLoaded', () => {
   enemy.addEventListener('animationend', () => {
     messageText.textContent = "Monster spotted! It’s battle time. My attacks are powered by learning. The more you know, the tougher I become!";
     message.classList.add('show');
+    button.onclick = () => {
+      window.location.href = 'battle.html';
+    };
   });
 
   resetScene();
   window.addEventListener('pageshow', resetScene);
- });
+});


### PR DESCRIPTION
## Summary
- Introduce battle page where Shellfin and the monster slide across the screen
- Style battle sequence with cross-screen animations
- Redirect "Continue" after the monster intro to the new battle page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b07b9f96988329aeb7a5f090321033