### PR TITLE
Fix monster sprite animation after rename

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -6,13 +6,16 @@
   }
   
 #shellfin,
-#enemy {
+#monster {
   position: absolute;
   left: 50%;
   bottom: 30%;
   width: 300px;
   max-width: 80vw;
   transform: translateX(100vw);
+}
+
+#shellfin {
   animation: swim 2s forwards;
 }
 
@@ -20,7 +23,7 @@
   animation: bubble-pop 0.5s forwards;
 }
 
-#enemy {
+#monster {
   display: none;
 }
 

--- a/js/script.js
+++ b/js/script.js
@@ -19,6 +19,7 @@ document.addEventListener('DOMContentLoaded', () => {
       if (e.animationName === 'bubble-pop') {
         shellfin.style.display = 'none';
         monster.style.display = 'block';
+        monster.style.animation = 'swim 2s forwards';
         shellfin.removeEventListener('animationend', handlePop);
       }
     });


### PR DESCRIPTION
## Summary
- Separate monster from shellfin animation rules so it starts hidden
- Start the monster's swim animation when it appears

## Testing
- `npm test` *(fails: Could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_e_68b08760068c83299c3eea7c3c1c2d6b