### PR TITLE
Fix monster sprite animation after rename

### DIFF
--- a/css/battle.css
+++ b/css/battle.css
@@ -43,3 +43,32 @@ html, body {
   from { left: -300px; }
   to { left: 100%; }
 }
+
+#message {
+  position: absolute;
+  left: 50%;
+  bottom: 0;
+  transform: translate(-50%, 100%);
+  width: 100%;
+  max-width: 500px;
+  background: #fff;
+  box-sizing: border-box;
+  padding: 24px;
+  border-radius: 16px 16px 0 0;
+  text-align: left;
+  transition: transform 0.5s ease-out;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+}
+
+#message.show {
+  transform: translate(-50%, 0);
+}
+
+#message p {
+  font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
+  font-size: 24px;
+  line-height: 1.4;
+  color: #272B34;
+}

--- a/css/style.css
+++ b/css/style.css
@@ -6,13 +6,16 @@
   }
   
 #shellfin,
-#enemy {
+#monster {
   position: absolute;
   left: 50%;
   bottom: 30%;
   width: 300px;
   max-width: 80vw;
   transform: translateX(100vw);
+}
+
+#shellfin {
   animation: swim 2s forwards;
 }
 
@@ -20,7 +23,11 @@
   animation: bubble-pop 0.5s forwards;
 }
 
-#enemy {
+#monster.pop {
+  animation: bubble-pop 0.5s forwards;
+}
+
+#monster {
   display: none;
 }
 

--- a/html/battle.html
+++ b/html/battle.html
@@ -14,5 +14,9 @@
     <img id="battle-monster" src="../images/monster_battle.png" alt="Monster" />
     <img id="battle-shellfin" src="../images/shellfin_battle.png" alt="Shellfin" />
   </div>
+  <div id="message">
+    <p>hello</p>
+  </div>
+  <script src="../js/battle.js"></script>
 </body>
 </html>

--- a/js/battle.js
+++ b/js/battle.js
@@ -1,0 +1,16 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const message = document.getElementById('message');
+  const monster = document.getElementById('battle-monster');
+  const shellfin = document.getElementById('battle-shellfin');
+
+  let done = 0;
+  function handleEnd() {
+    done++;
+    if (done === 2) {
+      message.classList.add('show');
+    }
+  }
+
+  monster.addEventListener('animationend', handleEnd);
+  shellfin.addEventListener('animationend', handleEnd);
+});

--- a/js/script.js
+++ b/js/script.js
@@ -19,6 +19,7 @@ document.addEventListener('DOMContentLoaded', () => {
       if (e.animationName === 'bubble-pop') {
         shellfin.style.display = 'none';
         monster.style.display = 'block';
+        monster.style.animation = 'swim 2s forwards';
         shellfin.removeEventListener('animationend', handlePop);
       }
     });
@@ -28,6 +29,7 @@ document.addEventListener('DOMContentLoaded', () => {
     shellfin.style.display = 'block';
     monster.style.display = 'none';
     shellfin.classList.remove('pop');
+    monster.classList.remove('pop');
     message.classList.remove('show');
     messageText.textContent = "Hi! I’m Shellfin – half turtle, half manta ray. Monsters have taken over my reef, and I need your help!";
     button.onclick = startBattle;
@@ -42,10 +44,20 @@ document.addEventListener('DOMContentLoaded', () => {
   monster.addEventListener('animationend', () => {
     messageText.textContent = "Monster spotted! It’s battle time. My attacks are powered by learning. The more you know, the tougher I become!";
     message.classList.add('show');
-    button.onclick = () => {
-      window.location.href = 'battle.html';
-    };
+    button.onclick = goToBattle;
   });
+
+  function goToBattle() {
+    message.classList.remove('show');
+    button.onclick = null;
+    monster.classList.add('pop');
+    monster.addEventListener('animationend', function handlePop(e) {
+      if (e.animationName === 'bubble-pop') {
+        window.location.href = 'battle.html';
+        monster.removeEventListener('animationend', handlePop);
+      }
+    });
+  }
 
   resetScene();
   window.addEventListener('pageshow', resetScene);


### PR DESCRIPTION
## Summary
- Pop the monster before navigating to battle and reset pop state
- Show a message after battle sprites slide in

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b08760068c83299c3eea7c3c1c2d6b