### PR TITLE
Animate battle transition after message

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -48,15 +48,29 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   function goToBattle() {
-    message.classList.remove('show');
     button.onclick = null;
-    monster.classList.add('pop');
-    monster.addEventListener('animationend', function handlePop(e) {
+
+    function handlePop(e) {
       if (e.animationName === 'bubble-pop') {
         window.location.href = 'battle.html';
         monster.removeEventListener('animationend', handlePop);
       }
-    });
+    }
+
+    function handleSlide(e) {
+      if (e.propertyName === 'transform') {
+        message.removeEventListener('transitionend', handleSlide);
+        // Clear the inline swim animation so the pop animation can run
+        monster.style.animation = 'none';
+        void monster.offsetWidth; // trigger reflow
+        monster.style.animation = '';
+        monster.classList.add('pop');
+        monster.addEventListener('animationend', handlePop);
+      }
+    }
+
+    message.addEventListener('transitionend', handleSlide);
+    message.classList.remove('show');
   }
 
   resetScene();


### PR DESCRIPTION
## Summary
- Clear monster's inline swim animation before triggering pop so Continue slides away message and transitions to battle

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b097d80b5c8329b102f522fb42f92f