### PR TITLE
Add battle stat boxes and character data

### DIFF
--- a/css/battle.css
+++ b/css/battle.css
@@ -34,3 +34,46 @@
   from { right: 100%; }
   to   { right: 55%; } /* stops slightly left of center */
 }
+
+.stat-box {
+  position: absolute;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 8px 12px;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.25);
+  border: 1px solid rgba(255, 255, 255, 0.5);
+  backdrop-filter: blur(10px);
+}
+
+#monster-stats {
+  top: 5%;
+  left: 35%;
+}
+
+#shellfin-stats {
+  bottom: 5%;
+  right: 35%;
+}
+
+.stat-box .name {
+  font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
+  font-size: 18px;
+  color: #fff;
+}
+
+.hp-bar {
+  width: 100px;
+  height: 12px;
+  border: 1px solid #fff;
+  border-radius: 6px;
+  margin-top: 4px;
+  overflow: hidden;
+}
+
+.hp-fill {
+  background: #FFBB00;
+  height: 100%;
+  width: 100%;
+}

--- a/css/style.css
+++ b/css/style.css
@@ -1,10 +1,28 @@
- html, body {
-     width: 100%;
-     height: 100%;
-     margin: 0;
-     overflow: hidden;
-     background: url('../images/background.png') no-repeat center/cover;
-  }
+html, body {
+    width: 100%;
+    height: 100%;
+    margin: 0;
+    overflow: hidden;
+    background: url('../images/background.png') no-repeat center/cover;
+ }
+
+#overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.25);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.5s ease-out;
+  z-index: 10;
+}
+
+#overlay.show {
+  opacity: 1;
+  pointer-events: auto;
+}
   
 #shellfin,
 #monster {
@@ -18,6 +36,10 @@
 }
 
 #shellfin.pop {
+  animation: bubble-pop 0.5s forwards;
+}
+
+#monster.pop {
   animation: bubble-pop 0.5s forwards;
 }
 
@@ -60,6 +82,7 @@
     display: flex;
     flex-direction: column;
     align-items: flex-start;
+    z-index: 20;
   }
  
  #message.show {

--- a/data/characters.json
+++ b/data/characters.json
@@ -1,0 +1,16 @@
+{
+  "heroes": {
+    "shellfin": {
+      "name": "Shellfin",
+      "attack": 10,
+      "health": 100
+    }
+  },
+  "monsters": {
+    "octomurk": {
+      "name": "Octomurk",
+      "attack": 12,
+      "health": 100
+    }
+  }
+}

--- a/html/index.html
+++ b/html/index.html
@@ -14,16 +14,24 @@
   <div id="game">
      <img id="shellfin" src="../images/shellfin.png" alt="Shellfin" />
      <img id="monster" src="../images/monster_battle.png" alt="monster" />
-     <div id="overlay"></div>
   </div>
   <div id="battle" style="display: none;">
     <img id="battle-monster" src="../images/monster_battle.png" alt="Monster" />
     <img id="battle-shellfin" src="../images/shellfin_battle.png" alt="Shellfin" />
+    <div id="monster-stats" class="stat-box">
+      <div class="name"></div>
+      <div class="hp-bar"><div class="hp-fill"></div></div>
+    </div>
+    <div id="shellfin-stats" class="stat-box">
+      <div class="name"></div>
+      <div class="hp-bar"><div class="hp-fill"></div></div>
+    </div>
   </div>
+  <div id="overlay"></div>
   <div id="message">
     <img src="../images/shellfin_message.png" alt="Shellfin avatar" />
     <p>Hi! I’m Shellfin – half turtle, half manta ray. Monsters have taken over my reef, and I need your help!</p>
-    <button>Continue</button>
+    <button type="button">Continue</button>
   </div>
     <script src="../js/script.js"></script>
     <script src="../js/battle.js"></script>

--- a/js/battle.js
+++ b/js/battle.js
@@ -1,12 +1,31 @@
 document.addEventListener('DOMContentLoaded', () => {
   const message = document.getElementById('message');
+  const overlay = document.getElementById('overlay');
   const monster = document.getElementById('battle-monster');
   const shellfin = document.getElementById('battle-shellfin');
+  const monsterStats = document.getElementById('monster-stats');
+  const shellfinStats = document.getElementById('shellfin-stats');
+  const monsterName = monsterStats.querySelector('.name');
+  const monsterHpFill = monsterStats.querySelector('.hp-fill');
+  const shellfinName = shellfinStats.querySelector('.name');
+  const shellfinHpFill = shellfinStats.querySelector('.hp-fill');
+
+  fetch('../data/characters.json')
+    .then((res) => res.json())
+    .then((data) => {
+      const hero = data.heroes.shellfin;
+      const foe = data.monsters.octomurk;
+      shellfinName.textContent = hero.name;
+      monsterName.textContent = foe.name;
+      shellfinHpFill.style.width = hero.health + '%';
+      monsterHpFill.style.width = foe.health + '%';
+    });
 
   let done = 0;
   function handleEnd() {
     done++;
     if (done === 2) {
+      overlay.classList.add('show');
       message.classList.add('show');
     }
   }

--- a/js/script.js
+++ b/js/script.js
@@ -47,11 +47,13 @@ document.addEventListener('DOMContentLoaded', () => {
     monster.style.animation = '';
   }
 
-  monster.addEventListener('animationend', () => {
-    messageText.textContent = "Monster spotted! It’s battle time. My attacks are powered by learning. The more you know, the tougher I become!";
-    overlay.classList.add('show');
-    message.classList.add('show');
-    button.onclick = goToBattle;
+  monster.addEventListener('animationend', (e) => {
+    if (e.animationName === 'swim') {
+      messageText.textContent = "Monster spotted! It’s battle time. My attacks are powered by learning. The more you know, the tougher I become!";
+      overlay.classList.add('show');
+      message.classList.add('show');
+      button.onclick = goToBattle;
+    }
   });
 
   function goToBattle() {


### PR DESCRIPTION
## Summary
- Display glass-style stat boxes for Shellfin and Octomurk with names and HP bars
- Load character information from new JSON file
- Dim background with a translucent overlay for all messages and ensure monster screen transitions smoothly into battle
- Allow monster pop animation to mirror Shellfin and gate message trigger to its swim completion
## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0aaecaa188329896aadb1074edf51