### PR TITLE
Add question dialog and sample question data

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -66,7 +66,8 @@ html, body {
   }
 }
 
- #message {
+ #message,
+ #question {
     position: absolute;
     left: 50%;
     bottom: 0;
@@ -84,12 +85,14 @@ html, body {
     align-items: flex-start;
     z-index: 20;
   }
- 
- #message.show {
+
+ #message.show,
+ #question.show {
    transform: translate(-50%, 0);
  }
 
-  #message p {
+  #message p,
+  #question p {
     font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
     font-size: 24px;
     line-height: 1.4;
@@ -100,7 +103,8 @@ html, body {
    width: 64px;
  }
 
-  #message button {
+  #message button,
+  #question button {
     width: 100%;
     height: 56px;
     background: #006AFF;
@@ -109,4 +113,27 @@ html, body {
     border-radius: 8px;
     font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
     font-size: 18px;
+  }
+
+  #question .progress-bar {
+    width: 100%;
+    height: 16px;
+    background: #F6F6F6;
+    border-radius: 8px;
+    overflow: hidden;
+    margin-bottom: 16px;
+  }
+
+  #question .progress-fill {
+    width: 100%;
+    height: 100%;
+    background: #006AFF;
+  }
+
+  #question .choices {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    width: 100%;
+    margin-top: 16px;
   }

--- a/data/questions.json
+++ b/data/questions.json
@@ -1,0 +1,15 @@
+{
+  "Walkthrough": [
+    {
+      "name": "Question 1",
+      "number": 1,
+      "question": "Coral is a close relative of the sea anemone. Is coral a plant, a rock, or an animal?",
+      "choices": [
+        { "image": "", "name": "plant" },
+        { "image": "", "name": "rock" },
+        { "image": "", "name": "animal" }
+      ]
+    }
+  ]
+}
+

--- a/html/index.html
+++ b/html/index.html
@@ -33,6 +33,11 @@
     <p>Hi! I’m Shellfin – half turtle, half manta ray. Monsters have taken over my reef, and I need your help!</p>
     <button type="button">Continue</button>
   </div>
+  <div id="question">
+    <div class="progress-bar"><div class="progress-fill"></div></div>
+    <p></p>
+    <div class="choices"></div>
+  </div>
     <script src="../js/script.js"></script>
     <script src="../js/battle.js"></script>
   </body>

--- a/js/battle.js
+++ b/js/battle.js
@@ -9,6 +9,12 @@ document.addEventListener('DOMContentLoaded', () => {
   const monsterHpFill = monsterStats.querySelector('.hp-fill');
   const shellfinName = shellfinStats.querySelector('.name');
   const shellfinHpFill = shellfinStats.querySelector('.hp-fill');
+  const button = message.querySelector('button');
+  const questionBox = document.getElementById('question');
+  const questionText = questionBox.querySelector('p');
+  const choices = questionBox.querySelector('.choices');
+  const progressFill = questionBox.querySelector('.progress-fill');
+  let questions = [];
 
   fetch('../data/characters.json')
     .then((res) => res.json())
@@ -21,12 +27,39 @@ document.addEventListener('DOMContentLoaded', () => {
       monsterHpFill.style.width = foe.health + '%';
     });
 
+  fetch('../data/questions.json')
+    .then((res) => res.json())
+    .then((data) => {
+      questions = data.Walkthrough;
+    });
+
+  function showQuestion() {
+    message.classList.remove('show');
+    function handleSlide(e) {
+      if (e.propertyName === 'transform') {
+        message.removeEventListener('transitionend', handleSlide);
+        const q = questions[0];
+        questionText.textContent = q.question;
+        choices.innerHTML = '';
+        q.choices.forEach((choice) => {
+          const btn = document.createElement('button');
+          btn.textContent = choice.name;
+          choices.appendChild(btn);
+        });
+        progressFill.style.width = '100%';
+        questionBox.classList.add('show');
+      }
+    }
+    message.addEventListener('transitionend', handleSlide);
+  }
+
   let done = 0;
   function handleEnd() {
     done++;
     if (done === 2) {
       overlay.classList.add('show');
       message.classList.add('show');
+      button.onclick = showQuestion;
     }
   }
 


### PR DESCRIPTION
## Summary
- style question popup matching message styles with progress bar
- show question box after battle message and populate with choices
- add initial questions data file

## Testing
- `node --check js/script.js`
- `node --check js/battle.js`


------
https://chatgpt.com/codex/tasks/task_e_68b0be6d42908329a407940ecd3b625d