### PR TITLE
Add dynamic question header and grid choices

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -87,8 +87,16 @@ html, body {
   }
 
  #message.show,
- #question.show {
-   transform: translate(-50%, 0);
+#question.show {
+  transform: translate(-50%, 0);
+}
+
+ #message h1,
+ #question h1 {
+   font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
+   font-size: 14px;
+   color: #858585;
+   margin: 0 0 8px;
  }
 
   #message p,
@@ -131,9 +139,28 @@ html, body {
   }
 
   #question .choices {
-    display: flex;
-    flex-direction: column;
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
     gap: 16px;
     width: 100%;
+    margin-top: 16px;
+  }
+
+  #question .choice {
+    background: #F6F6F6;
+    border-radius: 8px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    aspect-ratio: 1;
+  }
+
+  #question .choice p {
+    margin: 0;
+    text-align: center;
+  }
+
+  #question button {
     margin-top: 16px;
   }

--- a/html/index.html
+++ b/html/index.html
@@ -35,8 +35,10 @@
   </div>
   <div id="question">
     <div class="progress-bar"><div class="progress-fill"></div></div>
+    <h1></h1>
     <p></p>
     <div class="choices"></div>
+    <button type="button">Answer</button>
   </div>
     <script src="../js/script.js"></script>
     <script src="../js/battle.js"></script>

--- a/js/battle.js
+++ b/js/battle.js
@@ -11,6 +11,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const shellfinHpFill = shellfinStats.querySelector('.hp-fill');
   const button = message.querySelector('button');
   const questionBox = document.getElementById('question');
+  const questionHeading = questionBox.querySelector('h1');
   const questionText = questionBox.querySelector('p');
   const choices = questionBox.querySelector('.choices');
   const progressFill = questionBox.querySelector('.progress-fill');
@@ -44,12 +45,16 @@ document.addEventListener('DOMContentLoaded', () => {
       if (e.propertyName === 'transform') {
         message.removeEventListener('transitionend', handleSlide);
         const q = questions[0];
+        questionHeading.textContent = `Question ${q.number} of ${totalQuestions}`;
         questionText.textContent = q.question;
         choices.innerHTML = '';
         q.choices.forEach((choice) => {
-          const btn = document.createElement('button');
-          btn.textContent = choice.name;
-          choices.appendChild(btn);
+          const div = document.createElement('div');
+          div.classList.add('choice');
+          const p = document.createElement('p');
+          p.textContent = choice.name;
+          div.appendChild(p);
+          choices.appendChild(div);
         });
         const percent = (q.number / totalQuestions) * 100;
         progressFill.style.width = percent + '%';


### PR DESCRIPTION
## Summary
- Display question progress using an H1 heading styled with Arial Rounded
- Replace choice buttons with a responsive 2x2 grid of square options
- Add Answer button beneath the grid and update question loader

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0ffc053ac83298b693cfc6b8c8059