### PR TITLE
Add dedicated question module styling and interactivity

### DIFF
--- a/css/question.css
+++ b/css/question.css
@@ -1,0 +1,106 @@
+#question {
+  position: absolute;
+  left: 50%;
+  bottom: 0;
+  transform: translate(-50%, 100%);
+  width: 100%;
+  max-width: 500px;
+  background: #fff;
+  box-sizing: border-box;
+  padding: 24px;
+  border-radius: 16px 16px 0 0;
+  text-align: left;
+  transition: transform 0.5s ease-out;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  z-index: 20;
+}
+
+#question.show {
+  transform: translate(-50%, 0);
+}
+
+#question h1 {
+  font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
+  font-size: 14px;
+  color: #858585;
+  margin: 0 0 8px;
+}
+
+#question p {
+  font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
+  font-size: 24px;
+  line-height: 1.4;
+  color: #272B34;
+}
+
+#question button {
+  width: 100%;
+  height: 56px;
+  background: #006AFF;
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
+  font-size: 18px;
+  margin-top: 16px;
+}
+
+#question button:disabled {
+  background: #D6D6D6;
+  color: #272B34;
+}
+
+#question .progress-bar {
+  width: 100%;
+  height: 16px;
+  background: #F6F6F6;
+  border-radius: 8px;
+  overflow: hidden;
+  margin-bottom: 16px;
+}
+
+#question .progress-fill {
+  width: 0%;
+  height: 100%;
+  background: #006AFF;
+}
+
+#question .choices {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 16px;
+  width: 100%;
+  margin-top: 16px;
+}
+
+#question .choice {
+  background: #F6F6F6;
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  aspect-ratio: 1;
+  border: 3px solid transparent;
+  cursor: pointer;
+}
+
+#question .choice.selected {
+  background: #EBF3FF;
+  border-color: #006AFF;
+}
+
+#question .choice img {
+  width: 100%;
+  height: auto;
+  flex-grow: 1;
+  object-fit: contain;
+}
+
+#question .choice p {
+  margin: 8px 0 0;
+  text-align: center;
+}

--- a/css/style.css
+++ b/css/style.css
@@ -66,101 +66,54 @@ html, body {
   }
 }
 
- #message,
- #question {
-    position: absolute;
-    left: 50%;
-    bottom: 0;
-    transform: translate(-50%, 100%);
-    width: 100%;
-    max-width: 500px;
-    background: #fff;
-    box-sizing: border-box;
-    padding: 24px;
-    border-radius: 16px 16px 0 0;
-    text-align: left;
-    transition: transform 0.5s ease-out;
-    display: flex;
-    flex-direction: column;
-    align-items: flex-start;
-    z-index: 20;
-  }
+#message {
+  position: absolute;
+  left: 50%;
+  bottom: 0;
+  transform: translate(-50%, 100%);
+  width: 100%;
+  max-width: 500px;
+  background: #fff;
+  box-sizing: border-box;
+  padding: 24px;
+  border-radius: 16px 16px 0 0;
+  text-align: left;
+  transition: transform 0.5s ease-out;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  z-index: 20;
+}
 
- #message.show,
-#question.show {
+#message.show {
   transform: translate(-50%, 0);
 }
 
- #message h1,
- #question h1 {
-   font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
-   font-size: 14px;
-   color: #858585;
-   margin: 0 0 8px;
- }
+#message h1 {
+  font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
+  font-size: 14px;
+  color: #858585;
+  margin: 0 0 8px;
+}
 
-  #message p,
-  #question p {
-    font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
-    font-size: 24px;
-    line-height: 1.4;
-    color: #272B34;
-  }
+#message p {
+  font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
+  font-size: 24px;
+  line-height: 1.4;
+  color: #272B34;
+}
 
- #message img {
-   width: 64px;
- }
+#message img {
+  width: 64px;
+}
 
-  #message button,
-  #question button {
-    width: 100%;
-    height: 56px;
-    background: #006AFF;
-    color: #fff;
-    border: none;
-    border-radius: 8px;
-    font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
-    font-size: 18px;
-  }
-
-  #question .progress-bar {
-    width: 100%;
-    height: 16px;
-    background: #F6F6F6;
-    border-radius: 8px;
-    overflow: hidden;
-    margin-bottom: 16px;
-  }
-
-  #question .progress-fill {
-    width: 0%;
-    height: 100%;
-    background: #006AFF;
-  }
-
-  #question .choices {
-    display: grid;
-    grid-template-columns: repeat(2, 1fr);
-    gap: 16px;
-    width: 100%;
-    margin-top: 16px;
-  }
-
-  #question .choice {
-    background: #F6F6F6;
-    border-radius: 8px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 100%;
-    aspect-ratio: 1;
-  }
-
-  #question .choice p {
-    margin: 0;
-    text-align: center;
-  }
-
-  #question button {
-    margin-top: 16px;
-  }
+#message button {
+  width: 100%;
+  height: 56px;
+  background: #006AFF;
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
+  font-size: 18px;
+}

--- a/html/index.html
+++ b/html/index.html
@@ -8,6 +8,7 @@
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <title>Shellfin Intro</title>
     <link rel="stylesheet" href="../css/style.css" />
+    <link rel="stylesheet" href="../css/question.css" />
     <link rel="stylesheet" href="../css/battle.css" />
   </head>
   <body>
@@ -42,5 +43,6 @@
   </div>
     <script src="../js/script.js"></script>
     <script src="../js/battle.js"></script>
+    <script src="../js/question.js"></script>
   </body>
   </html>

--- a/js/battle.js
+++ b/js/battle.js
@@ -13,8 +13,9 @@ document.addEventListener('DOMContentLoaded', () => {
   const questionBox = document.getElementById('question');
   const questionHeading = questionBox.querySelector('h1');
   const questionText = questionBox.querySelector('p');
-  const choices = questionBox.querySelector('.choices');
-  const progressFill = questionBox.querySelector('.progress-fill');
+    const choices = questionBox.querySelector('.choices');
+    const progressFill = questionBox.querySelector('.progress-fill');
+    const questionButton = questionBox.querySelector('button');
   let questions = [];
   let totalQuestions = 0;
 
@@ -44,18 +45,25 @@ document.addEventListener('DOMContentLoaded', () => {
     function handleSlide(e) {
       if (e.propertyName === 'transform') {
         message.removeEventListener('transitionend', handleSlide);
-        const q = questions[0];
-        questionHeading.textContent = `Question ${q.number} of ${totalQuestions}`;
-        questionText.textContent = q.question;
-        choices.innerHTML = '';
-        q.choices.forEach((choice) => {
-          const div = document.createElement('div');
-          div.classList.add('choice');
-          const p = document.createElement('p');
-          p.textContent = choice.name;
-          div.appendChild(p);
-          choices.appendChild(div);
-        });
+          const q = questions[0];
+          questionHeading.textContent = `Question ${q.number} of ${totalQuestions}`;
+          questionText.textContent = q.question;
+          choices.innerHTML = '';
+          questionButton.disabled = true;
+          q.choices.forEach((choice) => {
+            const div = document.createElement('div');
+            div.classList.add('choice');
+            if (choice.image) {
+              const img = document.createElement('img');
+              img.src = `../images/questions/${choice.image}`;
+              img.alt = choice.name;
+              div.appendChild(img);
+            }
+            const p = document.createElement('p');
+            p.textContent = choice.name;
+            div.appendChild(p);
+            choices.appendChild(div);
+          });
         const percent = (q.number / totalQuestions) * 100;
         progressFill.style.width = percent + '%';
         questionBox.classList.add('show');

--- a/js/question.js
+++ b/js/question.js
@@ -1,0 +1,16 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const questionBox = document.getElementById('question');
+  const choicesContainer = questionBox.querySelector('.choices');
+  const button = questionBox.querySelector('button');
+
+  button.disabled = true;
+
+  choicesContainer.addEventListener('click', (e) => {
+    const choice = e.target.closest('.choice');
+    if (!choice) return;
+
+    Array.from(choicesContainer.children).forEach((c) => c.classList.remove('selected'));
+    choice.classList.add('selected');
+    button.disabled = false;
+  });
+});


### PR DESCRIPTION
## Summary
- Add question.css and question.js for focused question module styling and behavior
- Render choice images and highlight selections with blue border and fill
- Disable answer button until a choice is selected, then restore active styling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b108e5e66483299c579966317b6fc7