### PR TITLE
Add skip button for direct battle access

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -117,3 +117,12 @@ html, body {
   font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
   font-size: 18px;
 }
+
+#skip-button {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  padding: 4px 8px;
+  font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
+  z-index: 30;
+}

--- a/html/index.html
+++ b/html/index.html
@@ -12,6 +12,7 @@
     <link rel="stylesheet" href="../css/battle.css" />
   </head>
   <body>
+  <button id="skip-button">Skip</button>
   <div id="game">
      <img id="shellfin" src="../images/shellfin.png" alt="Shellfin" />
      <img id="monster" src="../images/monster_battle.png" alt="monster" />

--- a/js/script.js
+++ b/js/script.js
@@ -6,6 +6,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const button = message.querySelector('button');
   const overlay = document.getElementById('overlay');
   const battle = document.getElementById('battle');
+  const skipButton = document.getElementById('skip-button');
 
   shellfin.addEventListener('animationend', (e) => {
     if (e.animationName === 'swim') {
@@ -85,6 +86,14 @@ document.addEventListener('DOMContentLoaded', () => {
     overlay.classList.remove('show');
   }
 
+  function skipToBattle() {
+    document.getElementById('game').style.display = 'none';
+    battle.style.display = 'block';
+    message.classList.remove('show');
+    overlay.classList.remove('show');
+  }
+
   resetScene();
   window.addEventListener('pageshow', resetScene);
+  skipButton.addEventListener('click', skipToBattle);
 });


### PR DESCRIPTION
## Summary
- Add top-right Skip button to bypass intro and jump to battle
- Style button for visibility above overlay and messages
- Wire Skip button to hide intro elements and display battle

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b1b3cd5cf08329a492aead33c4fe76