### PR TITLE
Ensure question choices fit container

### DIFF
--- a/css/question.css
+++ b/css/question.css
@@ -86,6 +86,8 @@
   aspect-ratio: 1 / 1;
   border: 3px solid transparent;
   cursor: pointer;
+  padding: 16px;
+  box-sizing: border-box;
 }
 
 #question .choice.selected {
@@ -94,9 +96,8 @@
 }
 
 #question .choice img {
-  width: 50%;
+  width: 100%;
   height: auto;
-  flex-grow: 1;
   object-fit: contain;
 }
 


### PR DESCRIPTION
## Summary
- Prevent question choices from overflowing their grid by adding padding and border-box sizing
- Center choice content with full-width images for tighter layout

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b1b606bd1083298c5d065eec77a1cd