### PR TITLE
Add battle answer feedback and attack animations

### DIFF
--- a/css/battle.css
+++ b/css/battle.css
@@ -77,3 +77,23 @@
   height: 100%;
   width: 100%;
 }
+
+#battle-shellfin.attack {
+  animation: hero-attack 0.5s;
+}
+
+#battle-monster.attack {
+  animation: monster-attack 0.5s;
+}
+
+@keyframes hero-attack {
+  0% { transform: translateX(0); }
+  50% { transform: translateX(50px); }
+  100% { transform: translateX(0); }
+}
+
+@keyframes monster-attack {
+  0% { transform: translateX(0); }
+  50% { transform: translateX(-50px); }
+  100% { transform: translateX(0); }
+}

--- a/css/question.css
+++ b/css/question.css
@@ -105,3 +105,22 @@
   margin: 8px 0 0;
   text-align: center;
 }
+
+#question button.result {
+  width: 56px;
+  margin: 16px auto 0;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transform: scale(1.2);
+  transition: background 0.3s, width 0.3s, transform 0.3s;
+}
+
+#question button.correct {
+  background: #00BF00;
+}
+
+#question button.incorrect {
+  background: #E20000;
+}

--- a/js/battle.js
+++ b/js/battle.js
@@ -18,12 +18,15 @@ document.addEventListener('DOMContentLoaded', () => {
     const questionButton = questionBox.querySelector('button');
   let questions = [];
   let totalQuestions = 0;
+  let currentQuestion = 0;
+  let hero;
+  let foe;
 
   fetch('../data/characters.json')
     .then((res) => res.json())
     .then((data) => {
-      const hero = data.heroes.shellfin;
-      const foe = data.monsters.octomurk;
+      hero = data.heroes.shellfin;
+      foe = data.monsters.octomurk;
       shellfinName.textContent = hero.name;
       monsterName.textContent = foe.name;
       const heroHpPercent = ((hero.health - hero.damage) / hero.health) * 100;
@@ -41,35 +44,89 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 
   function showQuestion() {
-    message.classList.remove('show');
-    function handleSlide(e) {
-      if (e.propertyName === 'transform') {
-        message.removeEventListener('transitionend', handleSlide);
-          const q = questions[0];
-          questionHeading.textContent = `Question ${q.number} of ${totalQuestions}`;
-          questionText.textContent = q.question;
-          choices.innerHTML = '';
-          questionButton.disabled = true;
-          q.choices.forEach((choice) => {
-            const div = document.createElement('div');
-            div.classList.add('choice');
-            if (choice.image) {
-              const img = document.createElement('img');
-              img.src = `../images/questions/${choice.image}`;
-              img.alt = choice.name;
-              div.appendChild(img);
-            }
-            const p = document.createElement('p');
-            p.textContent = choice.name;
-            div.appendChild(p);
-            choices.appendChild(div);
-          });
-        const percent = (q.number / totalQuestions) * 100;
-        progressFill.style.width = percent + '%';
-        questionBox.classList.add('show');
+    function setupQuestion() {
+      const q = questions[currentQuestion];
+      questionHeading.textContent = `Question ${q.number} of ${totalQuestions}`;
+      questionText.textContent = q.question;
+      choices.innerHTML = '';
+      questionButton.disabled = true;
+      q.choices.forEach((choice) => {
+        const div = document.createElement('div');
+        div.classList.add('choice');
+        div.dataset.correct = choice.correct;
+        if (choice.image) {
+          const img = document.createElement('img');
+          img.src = `../images/questions/${choice.image}`;
+          img.alt = choice.name;
+          div.appendChild(img);
+        }
+        const p = document.createElement('p');
+        p.textContent = choice.name;
+        div.appendChild(p);
+        choices.appendChild(div);
+      });
+      const percent = (q.number / totalQuestions) * 100;
+      progressFill.style.width = percent + '%';
+      questionBox.classList.add('show');
+    }
+
+    if (message.classList.contains('show')) {
+      function handleSlide(e) {
+        if (e.propertyName === 'transform') {
+          message.removeEventListener('transitionend', handleSlide);
+          setupQuestion();
+        }
+      }
+      message.addEventListener('transitionend', handleSlide);
+      message.classList.remove('show');
+    } else {
+      setupQuestion();
+    }
+  }
+
+  document.addEventListener('answer-submitted', (e) => {
+    heroAttack(e.detail.correct);
+  });
+
+  function heroAttack(correct) {
+    shellfin.classList.add('attack');
+    foe.damage += hero.attack;
+    const percent = ((foe.health - foe.damage) / foe.health) * 100;
+    monsterHpFill.style.width = percent + '%';
+    function handleHero(e) {
+      if (e.animationName === 'hero-attack') {
+        shellfin.classList.remove('attack');
+        shellfin.removeEventListener('animationend', handleHero);
+        if (!correct) {
+          monsterAttack();
+        } else {
+          nextTurn();
+        }
       }
     }
-    message.addEventListener('transitionend', handleSlide);
+    shellfin.addEventListener('animationend', handleHero);
+  }
+
+  function monsterAttack() {
+    monster.classList.add('attack');
+    hero.damage += foe.attack;
+    const percent = ((hero.health - hero.damage) / hero.health) * 100;
+    shellfinHpFill.style.width = percent + '%';
+    function handleMonster(e) {
+      if (e.animationName === 'monster-attack') {
+        monster.classList.remove('attack');
+        monster.removeEventListener('animationend', handleMonster);
+        nextTurn();
+      }
+    }
+    monster.addEventListener('animationend', handleMonster);
+  }
+
+  function nextTurn() {
+    currentQuestion++;
+    if (currentQuestion < totalQuestions) {
+      showQuestion();
+    }
   }
 
   let done = 0;

--- a/js/question.js
+++ b/js/question.js
@@ -13,4 +13,31 @@ document.addEventListener('DOMContentLoaded', () => {
     choice.classList.add('selected');
     button.disabled = false;
   });
+
+  button.addEventListener('click', () => {
+    const choice = choicesContainer.querySelector('.choice.selected');
+    if (!choice) return;
+
+    button.disabled = true;
+    const isCorrect = choice.dataset.correct === 'true';
+
+    button.classList.add('result', isCorrect ? 'correct' : 'incorrect');
+    button.textContent = isCorrect ? '✓' : '✕';
+
+    setTimeout(() => {
+      function handleSlide(e) {
+        if (e.propertyName === 'transform') {
+          questionBox.removeEventListener('transitionend', handleSlide);
+          button.classList.remove('result', 'correct', 'incorrect');
+          button.textContent = 'Answer';
+          Array.from(choicesContainer.children).forEach((c) => c.classList.remove('selected'));
+          document.dispatchEvent(
+            new CustomEvent('answer-submitted', { detail: { correct: isCorrect } })
+          );
+        }
+      }
+      questionBox.addEventListener('transitionend', handleSlide);
+      questionBox.classList.remove('show');
+    }, 500);
+  });
 });


### PR DESCRIPTION
## Summary
- Show check or X and color feedback on answer submissions
- Animate hero attacks and conditional monster counterattacks with HP bar updates
- Wire question choices to correctness data and loop through questions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b1bb3f86288329941cec4ecc42c929