### PR TITLE
Add question feedback messages and smooth battle animations

### DIFF
--- a/css/battle.css
+++ b/css/battle.css
@@ -79,11 +79,11 @@
 }
 
 #battle-shellfin.attack {
-  animation: hero-attack 0.5s;
+  animation: hero-attack 0.5s ease-in-out;
 }
 
 #battle-monster.attack {
-  animation: monster-attack 0.5s;
+  animation: monster-attack 0.5s ease-in-out;
 }
 
 @keyframes hero-attack {

--- a/css/question.css
+++ b/css/question.css
@@ -107,14 +107,10 @@
 }
 
 #question button.result {
-  width: 56px;
-  margin: 16px auto 0;
-  border-radius: 50%;
   display: flex;
   align-items: center;
   justify-content: center;
-  transform: scale(1.2);
-  transition: background 0.3s, width 0.3s, transform 0.3s;
+  transition: background 0.3s;
 }
 
 #question button.correct {

--- a/js/battle.js
+++ b/js/battle.js
@@ -88,6 +88,18 @@ document.addEventListener('DOMContentLoaded', () => {
     heroAttack(e.detail.correct);
   });
 
+  function showFeedback(correct) {
+    const text = correct
+      ? 'Awesome job! Only two more hits needed to take Octomurk down. Let’s do it!'
+      : 'Ouch, that hurt! Don’t worry though, you still do damage when you get the question wrong.';
+    message.querySelector('p').textContent = text;
+    overlay.classList.add('show');
+    message.classList.add('show');
+    button.onclick = () => {
+      nextTurn();
+    };
+  }
+
   function heroAttack(correct) {
     shellfin.classList.add('attack');
     foe.damage += hero.attack;
@@ -100,7 +112,7 @@ document.addEventListener('DOMContentLoaded', () => {
         if (!correct) {
           monsterAttack();
         } else {
-          nextTurn();
+          showFeedback(true);
         }
       }
     }
@@ -116,7 +128,7 @@ document.addEventListener('DOMContentLoaded', () => {
       if (e.animationName === 'monster-attack') {
         monster.classList.remove('attack');
         monster.removeEventListener('animationend', handleMonster);
-        nextTurn();
+        showFeedback(false);
       }
     }
     monster.addEventListener('animationend', handleMonster);


### PR DESCRIPTION
## Summary
- Keep answer results full-width with green or red styling
- Show contextual encouragement after each attack
- Smooth out attack motion for hero and monster

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b1e367fb80832995c7c2da60a3da75