### PR TITLE
Delay message box and adjust battle attack order

### DIFF
--- a/js/battle.js
+++ b/js/battle.js
@@ -89,7 +89,11 @@ document.addEventListener('DOMContentLoaded', () => {
 
   document.addEventListener('answer-submitted', (e) => {
     overlay.classList.remove('show');
-    heroAttack(e.detail.correct);
+    if (e.detail.correct) {
+      heroAttack(true);
+    } else {
+      monsterAttack(() => heroAttack(false, () => showFeedback(false)));
+    }
   });
 
   function showFeedback(correct) {
@@ -104,7 +108,7 @@ document.addEventListener('DOMContentLoaded', () => {
     };
   }
 
-  function heroAttack(correct) {
+  function heroAttack(correct, after) {
     setTimeout(() => {
       shellfin.classList.add('attack');
       function handleHero(e) {
@@ -118,10 +122,10 @@ document.addEventListener('DOMContentLoaded', () => {
             if (ev.propertyName === 'width') {
               monsterHpFill.removeEventListener('transitionend', afterBar);
               setTimeout(() => {
-                if (!correct) {
-                  monsterAttack();
+                if (after) {
+                  after();
                 } else {
-                  showFeedback(true);
+                  showFeedback(correct);
                 }
               }, 1200);
             }
@@ -133,7 +137,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }, ATTACK_DELAY_MS);
   }
 
-  function monsterAttack() {
+  function monsterAttack(after) {
     setTimeout(() => {
       monster.classList.add('attack');
       function handleMonster(e) {
@@ -147,7 +151,11 @@ document.addEventListener('DOMContentLoaded', () => {
             if (ev.propertyName === 'width') {
               shellfinHpFill.removeEventListener('transitionend', afterBar);
               setTimeout(() => {
-                showFeedback(false);
+                if (after) {
+                  after();
+                } else {
+                  showFeedback(false);
+                }
               }, 1200);
             }
           }
@@ -178,9 +186,11 @@ document.addEventListener('DOMContentLoaded', () => {
           if (statsDone === 2) {
             shellfinStats.removeEventListener('transitionend', statsHandler);
             monsterStats.removeEventListener('transitionend', statsHandler);
-            overlay.classList.add('show');
-            message.classList.add('show');
-            button.onclick = showQuestion;
+            setTimeout(() => {
+              overlay.classList.add('show');
+              message.classList.add('show');
+              button.onclick = showQuestion;
+            }, 600);
           }
         }
       }


### PR DESCRIPTION
## Summary
- Add 600ms pause after stat boxes appear before showing the opening message
- Refactor attack routines so enemy strikes first on wrong answers while preserving hero damage

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b210d064d88329827924acb7576f72