### PR TITLE
Show dead monster after victory

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -63,6 +63,10 @@ html, body {
   animation: bubble-pop 0.5s forwards;
 }
 
+#monster.pop-in {
+  animation: bubble-pop-in 0.5s forwards;
+}
+
 #monster {
   display: none;
 }
@@ -83,6 +87,21 @@ html, body {
   100% {
     transform: translateX(-50%) scale(0);
     opacity: 0;
+  }
+}
+
+@keyframes bubble-pop-in {
+  0% {
+    transform: translateX(-50%) scale(0);
+    opacity: 0;
+  }
+  80% {
+    transform: translateX(-50%) scale(1.2);
+    opacity: 1;
+  }
+  100% {
+    transform: translateX(-50%) scale(1);
+    opacity: 1;
   }
 }
 

--- a/js/battle.js
+++ b/js/battle.js
@@ -16,6 +16,10 @@ document.addEventListener('DOMContentLoaded', () => {
     const choices = questionBox.querySelector('.choices');
     const progressFill = questionBox.querySelector('.progress-fill');
     const questionButton = questionBox.querySelector('button');
+  const game = document.getElementById('game');
+  const introMonster = document.getElementById('monster');
+  const introShellfin = document.getElementById('shellfin');
+  const battleDiv = document.getElementById('battle');
   let questions = [];
   let totalQuestions = 0;
   let currentQuestion = 0;
@@ -116,7 +120,29 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   function endBattle(result) {
-    message.querySelector('p').textContent = result === 'win' ? 'win' : 'lose';
+    if (result === 'win') {
+      setTimeout(() => {
+        battleDiv.style.display = 'none';
+        game.style.display = 'block';
+        introShellfin.style.display = 'none';
+        introMonster.src = '../images/monster_battle_dead.png';
+        introMonster.style.display = 'block';
+        introMonster.classList.remove('pop', 'pop-in');
+        introMonster.style.animation = 'none';
+        introMonster.style.transform = 'translateX(-50%) scale(0)';
+        void introMonster.offsetWidth;
+        introMonster.style.animation = '';
+        introMonster.classList.add('pop-in');
+        setTimeout(() => {
+          message.querySelector('p').textContent = 'win';
+          overlay.classList.add('show');
+          message.classList.add('show');
+          button.onclick = null;
+        }, 600);
+      }, 300);
+      return;
+    }
+    message.querySelector('p').textContent = 'lose';
     overlay.classList.add('show');
     message.classList.add('show');
     button.onclick = null;


### PR DESCRIPTION
## Summary
- After defeating a monster, transition back to the intro scene and pop in a dead monster sprite before showing the victory message.
- Add pop-in animation for the monster and corresponding CSS keyframes.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b23bfa78f883299355602e1e1e1889