### PR TITLE
feat: add hero win modal

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -157,6 +157,75 @@ html, body {
   font-size: 18px;
 }
 
+#message .generic-content {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+}
+
+#message .win-content {
+  display: none;
+  flex-direction: column;
+  align-items: center;
+}
+
+#message.win {
+  text-align: center;
+  align-items: center;
+}
+
+#message.win .generic-content {
+  display: none;
+}
+
+#message.win .win-content {
+  display: flex;
+}
+
+#message.win .hero-name {
+  font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
+  font-size: 40px;
+  color: #272B34;
+  margin: 0;
+}
+
+#message.win .hero-level,
+#message.win .stat-box .label {
+  font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
+  font-size: 14px;
+  color: #858585;
+  margin: 0;
+}
+
+#message.win .hero-sprite {
+  width: 120px;
+  margin: 16px 0;
+}
+
+#message.win .stats {
+  display: flex;
+  gap: 16px;
+  margin: 16px 0;
+  width: 100%;
+}
+
+#message.win .stat-box {
+  background: #F6F6F6;
+  border-radius: 8px;
+  padding: 8px 16px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  flex: 1;
+}
+
+#message.win .stat-box .value {
+  font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
+  font-size: 24px;
+  color: #006AFF;
+  margin: 0;
+}
+
 #skip-button {
   position: absolute;
   top: 10px;

--- a/html/index.html
+++ b/html/index.html
@@ -32,9 +32,27 @@
   </div>
   <div id="overlay"></div>
   <div id="message">
-    <img src="../images/shellfin_message.png" alt="Shellfin avatar" />
-    <p>Hi! I’m Shellfin – half turtle, half manta ray. Monsters have taken over my reef, and I need your help!</p>
-    <button type="button">Continue</button>
+    <div class="generic-content">
+      <img src="../images/shellfin_message.png" alt="Shellfin avatar" />
+      <p>Hi! I’m Shellfin – half turtle, half manta ray. Monsters have taken over my reef, and I need your help!</p>
+      <button type="button">Continue</button>
+    </div>
+    <div class="win-content">
+      <h1 class="hero-name"></h1>
+      <p class="hero-level"></p>
+      <img class="hero-sprite" src="" alt="Hero sprite" />
+      <div class="stats">
+        <div class="stat-box">
+          <p class="label">Attack</p>
+          <p class="value attack"></p>
+        </div>
+        <div class="stat-box">
+          <p class="label">Health</p>
+          <p class="value health"></p>
+        </div>
+      </div>
+      <button type="button">Claim Rewards</button>
+    </div>
   </div>
   <div id="question">
     <div class="progress-bar"><div class="progress-fill"></div></div>

--- a/js/battle.js
+++ b/js/battle.js
@@ -9,7 +9,15 @@ document.addEventListener('DOMContentLoaded', () => {
   const monsterHpFill = monsterStats.querySelector('.hp-fill');
   const shellfinName = shellfinStats.querySelector('.name');
   const shellfinHpFill = shellfinStats.querySelector('.hp-fill');
-  const button = message.querySelector('button');
+  const genericContent = message.querySelector('.generic-content');
+  const winContent = message.querySelector('.win-content');
+  const button = genericContent.querySelector('button');
+  const heroNameDisplay = winContent.querySelector('.hero-name');
+  const heroLevelDisplay = winContent.querySelector('.hero-level');
+  const heroSpriteDisplay = winContent.querySelector('.hero-sprite');
+  const attackDisplay = winContent.querySelector('.attack');
+  const healthDisplay = winContent.querySelector('.health');
+  const claimButton = winContent.querySelector('button');
   const questionBox = document.getElementById('question');
   const questionHeading = questionBox.querySelector('h1');
   const questionText = questionBox.querySelector('p');
@@ -115,7 +123,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const text = correct
       ? 'Awesome job! Only two more hits needed to take Octomurk down. Let’s do it!'
       : 'Ouch, that hurt! Don’t worry though, you still do damage when you get the question wrong.';
-    message.querySelector('p').textContent = text;
+    message.querySelector('.generic-content p').textContent = text;
     overlay.classList.add('show');
     message.classList.add('show');
     button.onclick = () => {
@@ -138,15 +146,20 @@ document.addEventListener('DOMContentLoaded', () => {
         introMonster.style.animation = '';
         introMonster.classList.add('pop-in');
         setTimeout(() => {
-          message.querySelector('p').textContent = 'win';
+          heroNameDisplay.textContent = hero.name;
+          heroLevelDisplay.textContent = `Level ${hero.level}`;
+          heroSpriteDisplay.src = `../images/${hero.name.toLowerCase()}_message.png`;
+          attackDisplay.textContent = hero.attack;
+          healthDisplay.textContent = hero.health - hero.damage;
+          message.classList.add('win');
           overlay.classList.add('show');
           message.classList.add('show');
-          button.onclick = null;
-        }, 600);
+          claimButton.onclick = null;
+        }, 2400);
       }, 300);
       return;
     }
-    message.querySelector('p').textContent = 'lose';
+    message.querySelector('.generic-content p').textContent = 'lose';
     overlay.classList.add('show');
     message.classList.add('show');
     button.onclick = null;

--- a/js/script.js
+++ b/js/script.js
@@ -2,8 +2,8 @@ document.addEventListener('DOMContentLoaded', () => {
   const shellfin = document.getElementById('shellfin');
   const monster = document.getElementById('monster');
   const message = document.getElementById('message');
-  const messageText = message.querySelector('p');
-  const button = message.querySelector('button');
+  const messageText = message.querySelector('.generic-content p');
+  const button = message.querySelector('.generic-content button');
   const overlay = document.getElementById('overlay');
   const battle = document.getElementById('battle');
   const skipButton = document.getElementById('skip-button');
@@ -16,7 +16,7 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   function startBattle() {
-    message.classList.remove('show');
+    message.classList.remove('show', 'win');
     overlay.classList.remove('show');
     button.onclick = null;
     shellfin.classList.add('pop');
@@ -36,7 +36,7 @@ document.addEventListener('DOMContentLoaded', () => {
     battle.style.display = 'none';
     shellfin.classList.remove('pop');
     monster.classList.remove('pop');
-    message.classList.remove('show');
+    message.classList.remove('show', 'win');
     overlay.classList.remove('show');
     messageText.textContent = "Hi! I’m Shellfin – half turtle, half manta ray. Monsters have taken over my reef, and I need your help!";
     button.onclick = startBattle;
@@ -82,14 +82,14 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     message.addEventListener('transitionend', handleSlide);
-    message.classList.remove('show');
+    message.classList.remove('show', 'win');
     overlay.classList.remove('show');
   }
 
   function skipToBattle() {
     document.getElementById('game').style.display = 'none';
     battle.style.display = 'block';
-    message.classList.remove('show');
+    message.classList.remove('show', 'win');
     overlay.classList.remove('show');
   }
 


### PR DESCRIPTION
## Summary
- add victory modal showing hero name, level, sprite, attack, and health
- delay win modal by 2400ms after defeated enemy pops in
- refactor message handling for separate generic and win content

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b2744d8c108329bae951cc24052cc9