### PR TITLE
Enhance win screen with progress and stats

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -204,12 +204,14 @@ html, body {
 }
 
 #message.win .hero-sprite {
-  width: 300px;
+  width: 200px;
+  height: 200px;
   margin: 16px 0;
 }
 
 #message.win .stats {
   display: flex;
+  flex-wrap: wrap;
   gap: 16px;
   margin: 16px 0;
   width: 100%;
@@ -229,6 +231,32 @@ html, body {
   border: none;
   backdrop-filter: none;
   transition: none;
+}
+
+#message.win .stat-box.progress-box {
+  flex-basis: 100%;
+  align-items: stretch;
+}
+
+#message.win .stat-box.progress-box .level-labels {
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+  margin-bottom: 8px;
+}
+
+#message.win .stat-box.progress-box .progress-bar {
+  width: 100%;
+  height: 16px;
+  background: #FFFFFF;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+#message.win .stat-box.progress-box .progress-fill {
+  width: 0%;
+  height: 100%;
+  background: #006AFF;
 }
 
 #message.win .stat-box .value {

--- a/html/index.html
+++ b/html/index.html
@@ -38,20 +38,26 @@
       <button type="button">Continue</button>
     </div>
     <div class="win-content">
-      <h1 class="hero-name"></h1>
-      <p class="hero-level"></p>
+      <h1 class="hero-name">Mission Complete</h1>
       <img class="hero-sprite" src="" alt="Hero sprite" />
       <div class="stats">
         <div class="stat-box">
-          <p class="label">Attack</p>
+          <p class="label">Accuracy</p>
           <p class="value attack"></p>
         </div>
         <div class="stat-box">
-          <p class="label">Health</p>
+          <p class="label">Speed</p>
           <p class="value health"></p>
         </div>
+        <div class="stat-box progress-box">
+          <div class="level-labels">
+            <span class="hero-level current"></span>
+            <span class="hero-level next"></span>
+          </div>
+          <div class="progress-bar"><div class="progress-fill"></div></div>
+        </div>
       </div>
-      <button type="button">Claim Rewards</button>
+      <button type="button">Continue</button>
     </div>
   </div>
   <div id="question">

--- a/js/battle.js
+++ b/js/battle.js
@@ -13,10 +13,12 @@ document.addEventListener('DOMContentLoaded', () => {
   const winContent = message.querySelector('.win-content');
   const button = genericContent.querySelector('button');
   const heroNameDisplay = winContent.querySelector('.hero-name');
-  const heroLevelDisplay = winContent.querySelector('.hero-level');
   const heroSpriteDisplay = winContent.querySelector('.hero-sprite');
   const attackDisplay = winContent.querySelector('.attack');
   const healthDisplay = winContent.querySelector('.health');
+  const levelLeftDisplay = winContent.querySelector('.level-labels .current');
+  const levelRightDisplay = winContent.querySelector('.level-labels .next');
+  const xpFill = winContent.querySelector('.progress-fill');
   const claimButton = winContent.querySelector('button');
   const questionBox = document.getElementById('question');
   const questionHeading = questionBox.querySelector('h1');
@@ -34,6 +36,9 @@ document.addEventListener('DOMContentLoaded', () => {
   let hero;
   let foe;
   let feedbackShown = { correct: false, incorrect: false };
+  let correctAnswers = 0;
+  let startTime;
+  let endTime;
 
   const ATTACK_DELAY_MS = 1200;
 
@@ -59,13 +64,16 @@ document.addEventListener('DOMContentLoaded', () => {
     .then((data) => {
       const walkthrough = data.Walkthrough;
       questions = walkthrough.questions;
-      totalQuestions = walkthrough.total;
+      totalQuestions = questions.length;
     });
 
   function showQuestion() {
     overlay.classList.add('show');
     function setupQuestion() {
       const q = questions[currentQuestion];
+      if (currentQuestion === 0) {
+        startTime = Date.now();
+      }
       questionHeading.textContent = `Question ${q.number} of ${totalQuestions}`;
       questionText.textContent = q.question;
       choices.innerHTML = '';
@@ -107,9 +115,13 @@ document.addEventListener('DOMContentLoaded', () => {
   document.addEventListener('answer-submitted', (e) => {
     overlay.classList.remove('show');
     if (e.detail.correct) {
+      correctAnswers++;
       heroAttack(true);
     } else {
       monsterAttack(() => heroAttack(false, () => showFeedback(false)), 300);
+    }
+    if (currentQuestion === totalQuestions - 1) {
+      endTime = Date.now();
     }
   });
 
@@ -146,11 +158,15 @@ document.addEventListener('DOMContentLoaded', () => {
         introMonster.style.animation = '';
         introMonster.classList.add('pop-in');
         setTimeout(() => {
-          heroNameDisplay.textContent = hero.name;
-          heroLevelDisplay.textContent = `Level ${hero.level}`;
+          heroNameDisplay.textContent = 'Mission Complete';
           heroSpriteDisplay.src = `../images/characters/${hero.name.toLowerCase()}.png`;
-          attackDisplay.textContent = hero.attack;
-          healthDisplay.textContent = hero.health - hero.damage;
+          const accuracy = Math.round((correctAnswers / totalQuestions) * 100);
+          attackDisplay.textContent = `${accuracy}%`;
+          const speed = ((endTime - startTime) / 1000).toFixed(2);
+          healthDisplay.textContent = `${speed}s`;
+          levelLeftDisplay.textContent = `Level ${hero.level}`;
+          levelRightDisplay.textContent = `Level ${hero.level + 1}`;
+          xpFill.style.width = hero.experience + '%';
           message.classList.add('win');
           overlay.classList.add('show');
           message.classList.add('show');


### PR DESCRIPTION
## Summary
- Replace hero info with "Mission Complete" and resize hero sprite
- Show Accuracy and Speed stats and add experience progress bar
- Update continue button text

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b3c6b3fa888329b99352832f8391a3