### PR TITLE
Animate level-up progress and fix image paths

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -257,6 +257,7 @@ html, body {
   width: 0%;
   height: 100%;
   background: #006AFF;
+  transition: width 0.6s linear;
 }
 
 #message.win .stat-box .value {
@@ -264,6 +265,25 @@ html, body {
   font-size: 24px;
   color: #006AFF;
   margin: 0;
+}
+
+@keyframes hero-pop-in {
+  0% {
+    transform: scale(0);
+    opacity: 0;
+  }
+  80% {
+    transform: scale(1.2);
+    opacity: 1;
+  }
+  100% {
+    transform: scale(1);
+    opacity: 1;
+  }
+}
+
+#message.win .hero-sprite.pop-in {
+  animation: hero-pop-in 0.5s forwards;
 }
 
 #skip-button {

--- a/html/index.html
+++ b/html/index.html
@@ -15,7 +15,7 @@
   <div id="loading">Loading...</div>
   <button id="skip-button">Skip</button>
   <div id="game">
-     <img id="shellfin" src="../images/characters/shellfin.png" alt="Shellfin" />
+     <img id="shellfin" src="../images/characters/shellfin_level_1.png" alt="Shellfin" />
      <img id="monster" src="../images/battle/monster_battle.png" alt="monster" />
   </div>
   <div id="battle" style="display: none;">
@@ -41,6 +41,13 @@
       <h1 class="hero-name">Mission Complete</h1>
       <img class="hero-sprite" src="" alt="Hero sprite" />
       <div class="stats">
+        <div class="stat-box progress-box">
+          <div class="level-labels">
+            <span class="hero-level current"></span>
+            <span class="hero-level next"></span>
+          </div>
+          <div class="progress-bar"><div class="progress-fill"></div></div>
+        </div>
         <div class="stat-box">
           <p class="label">Accuracy</p>
           <p class="value attack"></p>
@@ -48,13 +55,6 @@
         <div class="stat-box">
           <p class="label">Speed</p>
           <p class="value health"></p>
-        </div>
-        <div class="stat-box progress-box">
-          <div class="level-labels">
-            <span class="hero-level current"></span>
-            <span class="hero-level next"></span>
-          </div>
-          <div class="progress-bar"><div class="progress-fill"></div></div>
         </div>
       </div>
       <button type="button">Continue</button>

--- a/js/battle.js
+++ b/js/battle.js
@@ -39,6 +39,7 @@ document.addEventListener('DOMContentLoaded', () => {
   let correctAnswers = 0;
   let startTime;
   let endTime;
+  let missionExperience = 0;
 
   const ATTACK_DELAY_MS = 1200;
 
@@ -59,12 +60,13 @@ document.addEventListener('DOMContentLoaded', () => {
       monsterHpFill.style.width = monsterHpPercent + '%';
     });
 
-  fetch('../data/questions.json')
+  fetch('../data/missions.json')
     .then((res) => res.json())
     .then((data) => {
       const walkthrough = data.Walkthrough;
       questions = walkthrough.questions;
       totalQuestions = questions.length;
+      missionExperience = walkthrough.experience;
     });
 
   function showQuestion() {
@@ -159,10 +161,10 @@ document.addEventListener('DOMContentLoaded', () => {
         introMonster.classList.add('pop-in');
         setTimeout(() => {
           heroNameDisplay.textContent = 'Mission Complete';
-          heroSpriteDisplay.src = `../images/characters/${hero.name.toLowerCase()}.png`;
+          heroSpriteDisplay.src = `../images/characters/${hero.levels[hero.level].image}`;
           const accuracy = Math.round((correctAnswers / totalQuestions) * 100);
           attackDisplay.textContent = `${accuracy}%`;
-          const speed = ((endTime - startTime) / 1000).toFixed(2);
+          const speed = Math.floor((endTime - startTime) / 1000);
           healthDisplay.textContent = `${speed}s`;
           levelLeftDisplay.textContent = `Level ${hero.level}`;
           levelRightDisplay.textContent = `Level ${hero.level + 1}`;
@@ -171,6 +173,30 @@ document.addEventListener('DOMContentLoaded', () => {
           overlay.classList.add('show');
           message.classList.add('show');
           claimButton.onclick = null;
+
+          setTimeout(() => {
+            const newExperience = hero.experience + missionExperience;
+            xpFill.addEventListener('transitionend', function handleXp(e) {
+              if (e.propertyName === 'width') {
+                xpFill.removeEventListener('transitionend', handleXp);
+                hero.experience = newExperience;
+                const nextLevel = hero.level + 1;
+                const nextLevelData = hero.levels[nextLevel];
+                if (nextLevelData && hero.experience >= Number(nextLevelData.start)) {
+                  hero.level = nextLevel;
+                  levelLeftDisplay.textContent = `Level ${hero.level}`;
+                  levelRightDisplay.textContent = `Level ${hero.level + 1}`;
+                  setTimeout(() => {
+                    heroSpriteDisplay.src = `../images/characters/${hero.levels[hero.level].image}`;
+                    heroSpriteDisplay.classList.remove('pop-in');
+                    void heroSpriteDisplay.offsetWidth;
+                    heroSpriteDisplay.classList.add('pop-in');
+                  }, 600);
+                }
+              }
+            });
+            xpFill.style.width = newExperience + '%';
+          }, 600);
         }, 3200);
       }, 300);
       return;

--- a/js/loader.js
+++ b/js/loader.js
@@ -5,7 +5,6 @@ document.addEventListener('DOMContentLoaded', () => {
   const loading = document.getElementById('loading');
   const imageSources = [
     '../images/background/background.png',
-    '../images/characters/shellfin.png',
     '../images/battle/monster_battle.png',
     '../images/battle/shellfin_battle.png',
     '../images/message/shellfin_message.png',
@@ -16,13 +15,19 @@ document.addEventListener('DOMContentLoaded', () => {
   // Fetch data ahead of time
   Promise.all([
     fetch('../data/characters.json').then((res) => res.json()),
-    fetch('../data/questions.json').then((res) => res.json())
+    fetch('../data/missions.json').then((res) => res.json())
   ])
-    .then(([characters, questions]) => {
+    .then(([characters, missions]) => {
       window.preloadedData.characters = characters;
-      window.preloadedData.questions = questions;
+      window.preloadedData.missions = missions;
+      // Collect hero level images
+      Object.values(characters.heroes).forEach((hero) => {
+        Object.values(hero.levels).forEach((level) => {
+          imageSources.push(`../images/characters/${level.image}`);
+        });
+      });
       // Collect question images
-      questions.Walkthrough.questions.forEach((q) => {
+      missions.Walkthrough.questions.forEach((q) => {
         q.choices.forEach((choice) => {
           if (choice.image) {
             imageSources.push(`../images/questions/${choice.image}`);


### PR DESCRIPTION
## Summary
- Place level progress bar above win stats and correct hero image paths
- Animate XP gain with delayed level-up sprite pop-in
- Load mission data and character level sprites during preloading

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b3cc0fe4388329bed0c54ea9cb85f7