### PR TITLE
Add skip win control and rename skip battle

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -286,11 +286,16 @@ html, body {
   animation: hero-pop-in 0.5s forwards;
 }
 
-#skip-button {
+#skip-buttons {
   position: absolute;
   top: 10px;
   right: 10px;
+  display: flex;
+  gap: 10px;
+  z-index: 30;
+}
+
+#skip-buttons button {
   padding: 4px 8px;
   font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
-  z-index: 30;
 }

--- a/html/index.html
+++ b/html/index.html
@@ -13,7 +13,10 @@
   </head>
   <body>
   <div id="loading">Loading...</div>
-  <button id="skip-button">Skip</button>
+  <div id="skip-buttons">
+    <button id="skip-button">Skip Battle</button>
+    <button id="skip-win-button">Skip Win</button>
+  </div>
   <div id="game">
      <img id="shellfin" src="../images/characters/shellfin_level_1.png" alt="Shellfin" />
      <img id="monster" src="../images/battle/monster_battle.png" alt="monster" />

--- a/js/battle.js
+++ b/js/battle.js
@@ -310,4 +310,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
   monster.addEventListener('animationend', handleEnd);
   shellfin.addEventListener('animationend', handleEnd);
+
+  document.addEventListener('skip-win', () => {
+    endBattle('win');
+  });
 });

--- a/js/script.js
+++ b/js/script.js
@@ -6,7 +6,8 @@ document.addEventListener('DOMContentLoaded', () => {
   const button = message.querySelector('.generic-content button');
   const overlay = document.getElementById('overlay');
   const battle = document.getElementById('battle');
-  const skipButton = document.getElementById('skip-button');
+  const skipBattleButton = document.getElementById('skip-button');
+  const skipWinButton = document.getElementById('skip-win-button');
 
   shellfin.addEventListener('animationend', (e) => {
     if (e.animationName === 'swim') {
@@ -93,7 +94,14 @@ document.addEventListener('DOMContentLoaded', () => {
     overlay.classList.remove('show');
   }
 
+  function skipToWin() {
+    message.classList.remove('show', 'win');
+    overlay.classList.remove('show');
+    document.dispatchEvent(new Event('skip-win'));
+  }
+
   resetScene();
   window.addEventListener('pageshow', resetScene);
-  skipButton.addEventListener('click', skipToBattle);
+  skipBattleButton.addEventListener('click', skipToBattle);
+  skipWinButton.addEventListener('click', skipToWin);
 });


### PR DESCRIPTION
## Summary
- Rename existing skip button to "Skip Battle" and add adjacent "Skip Win" control
- Style skip button group and wire skip-to-win logic
- Trigger win sequence when "Skip Win" is selected

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b3ce7189f08329a084f9ae1e718df2