### PR TITLE
Animate win experience and add stat icons

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -279,6 +279,14 @@ html, body {
   font-size: 24px;
   color: #006AFF;
   margin: 0;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+#message.win .stat-box .value .icon {
+  width: 24px;
+  height: 24px;
 }
 
 @keyframes hero-pop-in {

--- a/html/index.html
+++ b/html/index.html
@@ -57,11 +57,11 @@
         </div>
         <div class="stat-box">
           <p class="label">Accuracy</p>
-          <p class="value attack"></p>
+          <div class="value"><span class="attack"></span><img src="../images/message/Accuracy.svg" alt="Accuracy icon" class="icon" /></div>
         </div>
         <div class="stat-box">
           <p class="label">Speed</p>
-          <p class="value health"></p>
+          <div class="value"><span class="health"></span><img src="../images/message/Speed.svg" alt="Speed icon" class="icon" /></div>
         </div>
       </div>
       <button type="button">Continue</button>

--- a/js/battle.js
+++ b/js/battle.js
@@ -195,7 +195,10 @@ document.addEventListener('DOMContentLoaded', () => {
           attackDisplay.textContent = `${accuracy}%`;
           const speed = Math.floor((endTime - startTime) / 1000);
           healthDisplay.textContent = `${speed}s`;
+          xpFill.style.transition = 'none';
           updateLevelProgress();
+          void xpFill.offsetWidth;
+          xpFill.style.transition = 'width 0.6s linear';
           message.classList.add('win');
           overlay.classList.add('show');
           message.classList.add('show');
@@ -230,7 +233,7 @@ document.addEventListener('DOMContentLoaded', () => {
               100
             );
             xpFill.style.width = fillPercent + '%';
-          }, 600);
+          }, 1200);
         }, 3200);
       }, 300);
       return;


### PR DESCRIPTION
## Summary
- show current XP before awarding mission bonus and animate gain after 1200ms
- add accuracy and speed icons in win message

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b3d49103288329ac257a86a5ec729c