### PR TITLE
Animate win experience and add stat icons

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -255,15 +255,6 @@ html, body {
   position: relative;
 }
 
-#message.win .stat-box.progress-box .level-range {
-  position: absolute;
-  left: 0;
-  top: 0;
-  height: 100%;
-  width: 100%;
-  background: #FFFFFF;
-}
-
 #message.win .stat-box.progress-box .progress-fill {
   position: absolute;
   left: 0;
@@ -279,6 +270,14 @@ html, body {
   font-size: 24px;
   color: #006AFF;
   margin: 0;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+#message.win .stat-box .value .icon {
+  width: 24px;
+  height: 24px;
 }
 
 @keyframes hero-pop-in {

--- a/html/index.html
+++ b/html/index.html
@@ -50,18 +50,16 @@
             <span class="hero-level next"></span>
           </div>
           <div class="progress-bar">
-            <div class="level-range">
-              <div class="progress-fill"></div>
-            </div>
+            <div class="progress-fill"></div>
           </div>
         </div>
         <div class="stat-box">
           <p class="label">Accuracy</p>
-          <p class="value attack"></p>
+          <div class="value"><img src="../images/message/Accuracy.svg" alt="Accuracy icon" class="icon" /><span class="attack"></span></div>
         </div>
         <div class="stat-box">
           <p class="label">Speed</p>
-          <p class="value health"></p>
+          <div class="value"><img src="../images/message/Speed.svg" alt="Speed icon" class="icon" /><span class="health"></span></div>
         </div>
       </div>
       <button type="button">Continue</button>

--- a/js/battle.js
+++ b/js/battle.js
@@ -18,7 +18,6 @@ document.addEventListener('DOMContentLoaded', () => {
   const healthDisplay = winContent.querySelector('.health');
   const levelLeftDisplay = winContent.querySelector('.level-labels .current');
   const levelRightDisplay = winContent.querySelector('.level-labels .next');
-  const levelRange = winContent.querySelector('.level-range');
   const xpFill = winContent.querySelector('.progress-fill');
   const claimButton = winContent.querySelector('button');
   const questionBox = document.getElementById('question');
@@ -36,7 +35,6 @@ document.addEventListener('DOMContentLoaded', () => {
   let currentQuestion = 0;
   let hero;
   let foe;
-  let minLevelStart = 0;
   let maxLevelStart = 0;
   let feedbackShown = { correct: false, incorrect: false };
   let correctAnswers = 0;
@@ -62,7 +60,6 @@ document.addEventListener('DOMContentLoaded', () => {
       shellfinHpFill.style.width = heroHpPercent + '%';
       monsterHpFill.style.width = monsterHpPercent + '%';
       const starts = Object.values(hero.levels).map((l) => Number(l.start));
-      minLevelStart = Math.min(...starts);
       maxLevelStart = Math.max(...starts);
     });
 
@@ -83,11 +80,6 @@ document.addEventListener('DOMContentLoaded', () => {
     const nextStart = nextLevelData ? Number(nextLevelData.start) : maxLevelStart;
     levelLeftDisplay.textContent = `Level ${hero.level}`;
     levelRightDisplay.textContent = `Level ${hero.level + 1}`;
-    const total = maxLevelStart - minLevelStart || 1;
-    const rangeLeft = ((currentStart - minLevelStart) / total) * 100;
-    const rangeWidth = ((nextStart - currentStart) / total) * 100;
-    levelRange.style.left = rangeLeft + '%';
-    levelRange.style.width = rangeWidth + '%';
     const progressPercent = ((hero.experience - currentStart) / (nextStart - currentStart || 1)) * 100;
     if (reset) {
       xpFill.style.transition = 'none';
@@ -195,7 +187,10 @@ document.addEventListener('DOMContentLoaded', () => {
           attackDisplay.textContent = `${accuracy}%`;
           const speed = Math.floor((endTime - startTime) / 1000);
           healthDisplay.textContent = `${speed}s`;
+          xpFill.style.transition = 'none';
           updateLevelProgress();
+          void xpFill.offsetWidth;
+          xpFill.style.transition = 'width 0.6s linear';
           message.classList.add('win');
           overlay.classList.add('show');
           message.classList.add('show');
@@ -230,7 +225,7 @@ document.addEventListener('DOMContentLoaded', () => {
               100
             );
             xpFill.style.width = fillPercent + '%';
-          }, 600);
+          }, 1600);
         }, 3200);
       }, 300);
       return;


### PR DESCRIPTION
## Summary
- show current XP before awarding mission bonus and animate gain after 1600ms
- add accuracy and speed icons to left of win stats with added spacing
- simplify XP progress bar to span only current level and handle overflow when leveling up

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b3d49103288329ac257a86a5ec729c