### PR TITLE
Revamp mission complete UI and level-up sequence

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -190,23 +190,16 @@ html, body {
 
 #message.win .hero-name {
   font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
-  font-size: 40px;
+  font-size: 32px;
   color: #272B34;
   margin: 0;
 }
 
-#message.win .hero-level,
 #message.win .stat-box .label {
   font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
   font-size: 14px;
   color: #858585;
   margin: 0;
-}
-
-#message.win .hero-sprite {
-  width: 200px;
-  height: 200px;
-  margin: 16px 0;
 }
 
 #message.win .stats {
@@ -239,11 +232,13 @@ html, body {
   align-items: stretch;
 }
 
-#message.win .stat-box.progress-box .level-labels {
-  display: flex;
-  justify-content: space-between;
+#message.win .stat-box.progress-box .progress-label {
+  text-align: center;
   width: 100%;
   margin-bottom: 8px;
+  font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
+  font-size: 14px;
+  color: #858585;
 }
 
 #message.win .stat-box.progress-box .progress-bar {
@@ -265,6 +260,24 @@ html, body {
   transition: width 0.6s linear;
 }
 
+#message.win .stat-box.progress-box .level-up-badge {
+  position: absolute;
+  top: -8px;
+  right: -8px;
+  background: #00B600;
+  color: #fff;
+  font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
+  font-size: 12px;
+  border-radius: 50%;
+  padding: 4px 8px;
+  transform: scale(0);
+  opacity: 0;
+}
+
+#message.win .stat-box.progress-box .level-up-badge.show {
+  animation: level-up-pop 0.3s forwards;
+}
+
 #message.win .stat-box .value {
   font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
   font-size: 24px;
@@ -280,7 +293,7 @@ html, body {
   height: 24px;
 }
 
-@keyframes hero-pop-in {
+@keyframes level-up-pop {
   0% {
     transform: scale(0);
     opacity: 0;
@@ -293,10 +306,6 @@ html, body {
     transform: scale(1);
     opacity: 1;
   }
-}
-
-#message.win .hero-sprite.pop-in {
-  animation: hero-pop-in 0.5s forwards;
 }
 
 #skip-buttons {

--- a/html/index.html
+++ b/html/index.html
@@ -42,15 +42,12 @@
     </div>
     <div class="win-content">
       <h1 class="hero-name">Mission Complete</h1>
-      <img class="hero-sprite" src="" alt="Hero sprite" />
       <div class="stats">
         <div class="stat-box progress-box">
-          <div class="level-labels">
-            <span class="hero-level current"></span>
-            <span class="hero-level next"></span>
-          </div>
+          <p class="progress-label">Experience</p>
           <div class="progress-bar">
             <div class="progress-fill"></div>
+            <div class="level-up-badge">Level Up</div>
           </div>
         </div>
         <div class="stat-box">

--- a/js/battle.js
+++ b/js/battle.js
@@ -13,12 +13,10 @@ document.addEventListener('DOMContentLoaded', () => {
   const winContent = message.querySelector('.win-content');
   const button = genericContent.querySelector('button');
   const heroNameDisplay = winContent.querySelector('.hero-name');
-  const heroSpriteDisplay = winContent.querySelector('.hero-sprite');
   const attackDisplay = winContent.querySelector('.attack');
   const healthDisplay = winContent.querySelector('.health');
-  const levelLeftDisplay = winContent.querySelector('.level-labels .current');
-  const levelRightDisplay = winContent.querySelector('.level-labels .next');
   const xpFill = winContent.querySelector('.progress-fill');
+  const levelUpBadge = winContent.querySelector('.level-up-badge');
   const claimButton = winContent.querySelector('button');
   const questionBox = document.getElementById('question');
   const questionHeading = questionBox.querySelector('h1');
@@ -78,8 +76,6 @@ document.addEventListener('DOMContentLoaded', () => {
     const nextLevelData = hero.levels[hero.level + 1];
     const currentStart = Number(currentLevelData.start);
     const nextStart = nextLevelData ? Number(nextLevelData.start) : maxLevelStart;
-    levelLeftDisplay.textContent = `Level ${hero.level}`;
-    levelRightDisplay.textContent = `Level ${hero.level + 1}`;
     const progressPercent = ((hero.experience - currentStart) / (nextStart - currentStart || 1)) * 100;
     if (reset) {
       xpFill.style.transition = 'none';
@@ -182,7 +178,6 @@ document.addEventListener('DOMContentLoaded', () => {
         introMonster.classList.add('pop-in');
         setTimeout(() => {
           heroNameDisplay.textContent = 'Mission Complete';
-          heroSpriteDisplay.src = `../images/characters/${hero.levels[hero.level].image}`;
           const accuracy = Math.round((correctAnswers / totalQuestions) * 100);
           attackDisplay.textContent = `${accuracy}%`;
           const speed = Math.floor((endTime - startTime) / 1000);
@@ -209,12 +204,9 @@ document.addEventListener('DOMContentLoaded', () => {
                 if (nextLevelData && hero.experience >= Number(nextLevelData.start)) {
                   hero.level = nextLevel;
                   updateLevelProgress(true);
-                  setTimeout(() => {
-                    heroSpriteDisplay.src = `../images/characters/${hero.levels[hero.level].image}`;
-                    heroSpriteDisplay.classList.remove('pop-in');
-                    void heroSpriteDisplay.offsetWidth;
-                    heroSpriteDisplay.classList.add('pop-in');
-                  }, 600);
+                  levelUpBadge.classList.remove('show');
+                  void levelUpBadge.offsetWidth;
+                  levelUpBadge.classList.add('show');
                 } else {
                   updateLevelProgress();
                 }
@@ -225,6 +217,17 @@ document.addEventListener('DOMContentLoaded', () => {
               100
             );
             xpFill.style.width = fillPercent + '%';
+            claimButton.onclick = () => {
+              message.classList.remove('show');
+              overlay.classList.remove('show');
+              message.addEventListener(
+                'transitionend',
+                () => {
+                  window.location.href = '../html/walkthrough.html';
+                },
+                { once: true }
+              );
+            };
           }, 1600);
         }, 3200);
       }, 300);


### PR DESCRIPTION
## Summary
- Restyle mission-complete panel: remove hero sprite, center "Experience" label, and drop left/right level numbers.
- Add animated "Level Up" badge when the experience bar fills and a level is gained.
- Slide win message down on continue and redirect to walkthrough start.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b4ca259ba48329889b41c56f62cccc