### PR TITLE
Keep XP bar filled on level up and show hero after mission

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -71,6 +71,14 @@ html, body {
   display: none;
 }
 
+#game img.center {
+  top: 50%;
+  left: 50%;
+  bottom: auto;
+  transform: translate(-50%, -50%);
+  animation: none;
+}
+
 @keyframes swim {
   to { transform: translateX(-50%); }
 }
@@ -246,7 +254,7 @@ html, body {
   height: 16px;
   background: #D9D9D9;
   border-radius: 2px;
-  overflow: hidden;
+  overflow: visible;
   position: relative;
 }
 
@@ -262,17 +270,23 @@ html, body {
 
 #message.win .stat-box.progress-box .level-up-badge {
   position: absolute;
-  top: -8px;
-  right: -8px;
+  top: -20px;
+  right: -20px;
+  width: 56px;
+  height: 56px;
   background: #00B600;
   color: #fff;
   font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
   font-size: 12px;
   border-radius: 50%;
-  padding: 4px 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 0;
   transform: scale(0);
   opacity: 0;
-  z-index: 100;
+  z-index: 1000;
 }
 
 #message.win .stat-box.progress-box .level-up-badge.show {

--- a/html/index.html
+++ b/html/index.html
@@ -47,7 +47,7 @@
           <p class="progress-label">Experience</p>
           <div class="progress-bar">
             <div class="progress-fill"></div>
-            <div class="level-up-badge">Level Up</div>
+            <div class="level-up-badge">Level<br />Up</div>
           </div>
         </div>
         <div class="stat-box">

--- a/js/battle.js
+++ b/js/battle.js
@@ -200,7 +200,6 @@ document.addEventListener('DOMContentLoaded', () => {
                 xpFill.removeEventListener('transitionend', handleXp);
                 if (hero.experience >= nextStart) {
                   hero.level += 1;
-                  updateLevelProgress(true);
                   levelUpBadge.classList.remove('show');
                   void levelUpBadge.offsetWidth;
                   levelUpBadge.classList.add('show');
@@ -215,13 +214,11 @@ document.addEventListener('DOMContentLoaded', () => {
             claimButton.onclick = () => {
               message.classList.remove('show');
               overlay.classList.remove('show');
-              message.addEventListener(
-                'transitionend',
-                () => {
-                  window.location.href = '../html/walkthrough.html';
-                },
-                { once: true }
-              );
+              introMonster.style.display = 'none';
+              introShellfin.src = `../images/characters/${hero.levels[hero.level].image}`;
+              introShellfin.style.display = 'block';
+              introShellfin.classList.add('center');
+              message.addEventListener('transitionend', () => updateLevelProgress(true), { once: true });
             };
           }, 2400);
         }, 3200);


### PR DESCRIPTION
## Summary
- Keep XP bar at 100% when level up occurs, then reset after message closes
- Style Level Up badge as 56x56 circle on top of the bar and allow overflow
- After mission, Continue button hides message and centers upgraded hero sprite

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b4cf16762483299ed432db82e9c699