### PR TITLE
Fix hero evolution to show correct level sprite

### DIFF
--- a/js/battle.js
+++ b/js/battle.js
@@ -271,7 +271,7 @@ document.addEventListener('DOMContentLoaded', () => {
                         introShellfin.addEventListener('animationend', function handlePop(e) {
                           if (e.animationName === 'bubble-pop') {
                             introShellfin.removeEventListener('animationend', handlePop);
-                            introShellfin.src = `../images/characters/${hero.levels[hero.level].image}`;
+                            introShellfin.src = `../images/characters/${hero.levels[prevLevel + 1].image}`;
                             introShellfin.classList.remove('pop');
                             introShellfin.classList.add('pop-in');
                             introShellfin.addEventListener('animationend', function handlePopIn(ev2) {


### PR DESCRIPTION
## Summary
- ensure post-win hero evolution swaps to the immediate next level sprite

## Testing
- `node --check js/battle.js`


------
https://chatgpt.com/codex/tasks/task_e_68b5082fd688832990019998bf70f551