### PR TITLE
Display hero level and fix prevLevel tracking

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -158,6 +158,17 @@ html, body {
   width: 64px;
 }
 
+#hero-level-display {
+  position: fixed;
+  top: 10px;
+  left: 50%;
+  transform: translateX(-50%);
+  color: #fff;
+  font-size: 16px;
+  font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
+  z-index: 30;
+}
+
 #message button {
   width: 100%;
   height: 56px;

--- a/html/index.html
+++ b/html/index.html
@@ -17,6 +17,7 @@
     <button id="skip-button">Skip Battle</button>
     <button id="skip-win-button">Skip Win</button>
   </div>
+  <div id="hero-level-display"></div>
   <div id="game">
      <img id="shellfin" src="../images/characters/shellfin_level_1.png" alt="Shellfin" />
      <img id="monster" src="../images/battle/monster_battle.png" alt="monster" />

--- a/js/battle.js
+++ b/js/battle.js
@@ -30,6 +30,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const introMonster = document.getElementById('monster');
   const introShellfin = document.getElementById('shellfin');
   const battleDiv = document.getElementById('battle');
+  const levelDisplay = document.getElementById('hero-level-display');
   let questions = [];
   let totalQuestions = 0;
   let currentQuestion = 0;
@@ -41,7 +42,7 @@ document.addEventListener('DOMContentLoaded', () => {
   let startTime;
   let endTime;
   let missionExperience = 0;
-  let prevLevel;
+  let prevLevel = null;
 
   const ATTACK_DELAY_MS = 1200;
 
@@ -59,6 +60,12 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function applyDamage(attacker, defender) {
     defender.damage = Number(defender.damage) + Number(attacker.attack);
+  }
+
+  function updateHeroLevelDisplay() {
+    if (levelDisplay && hero) {
+      levelDisplay.textContent = `Level ${hero.level}`;
+    }
   }
 
   function loadData() {
@@ -83,6 +90,8 @@ document.addEventListener('DOMContentLoaded', () => {
     questions = walkthrough.questions;
     totalQuestions = questions.length;
     missionExperience = walkthrough.experience;
+
+    updateHeroLevelDisplay();
   }
 
   document.addEventListener('assets-loaded', loadData);
@@ -212,17 +221,19 @@ document.addEventListener('DOMContentLoaded', () => {
           setTimeout(() => {
             const currentStart = Number(hero.levels[hero.level].start);
             const nextStart = Number(hero.levels[hero.level + 1]?.start || maxLevelStart);
-            prevLevel = hero.level;
+            prevLevel = null;
             hero.experience += missionExperience;
             xpFill.addEventListener('transitionend', function handleXp(e) {
               if (e.propertyName === 'width') {
                 xpFill.removeEventListener('transitionend', handleXp);
                 if (hero.experience >= nextStart) {
+                  prevLevel = hero.level;
                   hero.level += 1;
                   saveCharacterData();
                   levelUpBadge.classList.remove('show');
                   void levelUpBadge.offsetWidth;
                   levelUpBadge.classList.add('show');
+                  updateHeroLevelDisplay();
                 }
               }
             });
@@ -235,7 +246,7 @@ document.addEventListener('DOMContentLoaded', () => {
               message.classList.remove('show');
               overlay.classList.remove('show');
               message.addEventListener('transitionend', () => updateLevelProgress(true), { once: true });
-
+              if (prevLevel === null) return;
               introMonster.classList.remove('pop', 'pop-in');
               introMonster.classList.add('pop');
               introMonster.addEventListener('animationend', function handleMonsterPop(e) {


### PR DESCRIPTION
## Summary
- Fix prevLevel tracking by only setting it when the hero actually levels up
- Show hero level at top center of screen during battle and win screens

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b50c76d2648329961bd7ef60867039