### PR TITLE
Display hero level and add reset progress button

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -16,6 +16,7 @@
   <div id="skip-buttons">
     <button id="skip-button">Skip Battle</button>
     <button id="skip-win-button">Skip Win</button>
+    <button id="reset-progress-button">Reset Progress</button>
   </div>
   <div id="hero-level-display"></div>
   <div id="game">

--- a/js/battle.js
+++ b/js/battle.js
@@ -30,6 +30,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const introMonster = document.getElementById('monster');
   const introShellfin = document.getElementById('shellfin');
   const battleDiv = document.getElementById('battle');
+  const heroLevelDisplay = document.getElementById('hero-level-display');
   let questions = [];
   let totalQuestions = 0;
   let currentQuestion = 0;
@@ -44,6 +45,12 @@ document.addEventListener('DOMContentLoaded', () => {
   let prevLevel;
 
   const ATTACK_DELAY_MS = 1200;
+
+  function updateHeroLevelDisplay() {
+    if (heroLevelDisplay && hero) {
+      heroLevelDisplay.textContent = `Level: ${hero.level}`;
+    }
+  }
 
   function saveCharacterData() {
     try {
@@ -83,6 +90,7 @@ document.addEventListener('DOMContentLoaded', () => {
     questions = walkthrough.questions;
     totalQuestions = questions.length;
     missionExperience = walkthrough.experience;
+    updateHeroLevelDisplay();
   }
 
   document.addEventListener('assets-loaded', loadData);
@@ -219,6 +227,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 xpFill.removeEventListener('transitionend', handleXp);
                 if (hero.experience >= nextStart) {
                   hero.level += 1;
+                  updateHeroLevelDisplay();
                   saveCharacterData();
                   levelUpBadge.classList.remove('show');
                   void levelUpBadge.offsetWidth;

--- a/js/script.js
+++ b/js/script.js
@@ -8,6 +8,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const battle = document.getElementById('battle');
   const skipBattleButton = document.getElementById('skip-button');
   const skipWinButton = document.getElementById('skip-win-button');
+  const resetProgressButton = document.getElementById('reset-progress-button');
 
   shellfin.addEventListener('animationend', (e) => {
     if (e.animationName === 'swim') {
@@ -118,4 +119,7 @@ document.addEventListener('DOMContentLoaded', () => {
   window.addEventListener('pageshow', resetScene);
   skipBattleButton.addEventListener('click', skipToBattle);
   skipWinButton.addEventListener('click', skipToWin);
+  if (resetProgressButton) {
+    resetProgressButton.addEventListener('click', resetProgress);
+  }
 });


### PR DESCRIPTION
## Summary
- Add reset progress button to debug controls and hook it to local storage reset
- Show hero level at top of page and update when leveling up

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5129885bc832994cb422ab9b7d36f