### PR TITLE
Ensure reset progress clears all saved data

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -102,10 +102,10 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   function resetProgress() {
-    localStorage.removeItem('characters');
-    // Optionally re-seed from your bundled defaults:
-    if (window.preloadedData?.characters) {
-      localStorage.setItem('characters', JSON.stringify(window.preloadedData.characters));
+    try {
+      localStorage.clear();
+    } catch (err) {
+      console.error('Failed to clear saved progress', err);
     }
     location.reload();
   }


### PR DESCRIPTION
## Summary
- Clear entire localStorage during progress reset
- Reload the page after clearing for a fresh start

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b513dbe3488329811d8a3f3393478f