### PR TITLE
Add post-win evolution message and full-width continue button

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -184,6 +184,7 @@ html, body {
   display: flex;
   flex-direction: column;
   align-items: flex-start;
+  width: 100%;
 }
 
 #message .win-content {

--- a/js/battle.js
+++ b/js/battle.js
@@ -338,8 +338,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
                           setTimeout(() => {
                             genericImg.src = '../images/message/shellfin_message.png';
-                            genericP.textContent = 'Ready for the next mission?';
-                            genericP.textContent = hadLevelUp ? 'test' : 'Ready for the next mission?';
+                        
+                            genericP.textContent =
+                              'Barnacle armor – awesome! Take on more missions to learn about the ocean and evolve me even further!';
                             button.textContent = 'Continue';
                             overlay.classList.add('show');
                             message.classList.add('show');


### PR DESCRIPTION
## Summary
- Show new evolution message after Shellfin transforms
- Stretch generic message container so continue button spans full width

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/reefrangers2/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68b51cd3d2c0832981db0a3660f0eda9