### PR TITLE
Add virtual joystick movement demo

### DIFF
--- a/test 2/index.html
+++ b/test 2/index.html
@@ -2,166 +2,99 @@
 <html>
 <head>
   <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Phaser 3 — 16×16 Tilemap + Grid Movement Demo</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
+  <title>Virtual Joystick Demo</title>
   <style>
-    html, body { height: 100%; margin: 0; background:#0b1020; }
+    html, body { height: 100%; margin: 0; touch-action: none; }
     #game { width: 100%; height: 100%; }
-    .hint { position: fixed; left: 12px; bottom: 12px; color: #cfe3ff; font: 12px/1.4 system-ui, sans-serif; opacity:.9 }
-    .hint code { background: #1a2240; padding:2px 4px; border-radius:4px }
   </style>
-  <!-- Phaser 3 CDN -->
   <script src="https://cdn.jsdelivr.net/npm/phaser@3.60.0/dist/phaser.min.js"></script>
 </head>
 <body>
   <div id="game"></div>
-  <div class="hint">
-    Replace image paths in <code>preload()</code> with your files:<br>
-    <code>assets/tiles.png</code> → 2×2 grid (16×16 each): wood, water, sand, grass<br>
-    <code>assets/boy_front.png</code>, <code>boy_back.png</code>, <code>boy_left.png</code>, <code>boy_right.png</code> (each 16×16)
-  </div>
-
 <script>
 (() => {
-  const TILE = 128;               // Each tile is 16×16
-  const SCALE = 2;               // Upscale for crisp pixels on modern screens
-  const SPEED = 600;             // pixels/second for tweened tile steps
-
+  const SPEED = 200;
   const config = {
     type: Phaser.AUTO,
     parent: 'game',
-    backgroundColor: '#2b3352',
-    pixelArt: true,
-    scale: { mode: Phaser.Scale.FIT, autoCenter: Phaser.Scale.CENTER_BOTH, width: 20*TILE*SCALE, height: 12*TILE*SCALE },
+    width: window.innerWidth,
+    height: window.innerHeight,
     physics: { default: 'arcade', arcade: { debug: false } },
     scene: { preload, create, update }
   };
 
+  let player;
+  let joystickBase, joystickThumb;
+  const joystickVector = new Phaser.Math.Vector2();
+  let joystickPointer = null;
+
   new Phaser.Game(config);
 
-  // --- Asset keys
-  const KEYS = {
-    tiles: 'tiles',
-    boyFront: 'boyFront',
-    boyBack:  'boyBack',
-    boyLeft:  'boyLeft',
-    boyRight: 'boyRight'
-  };
-
-  // Map indices: using a 2×2 tilesheet (32×32) of 16×16 tiles
-  // Layout expected:
-  // [0] wood | [1] water
-  // [2] sand | [3] grass
-  const TILE_INDEX = { WOOD:0, WATER:1, SAND:2, GRASS:3 };
-
-  // Simple demo map (20×12 tiles). 1 = water (blocked), others walkable.
-  const worldMap = [
-    [1,1,1,1,1,1,1,1,0,0,0,0,1,1,1,1,1,1,1,1],
-    [1,1,1,1,1,1,1,1,0,0,0,0,1,1,1,1,1,1,1,1],
-    [1,1,1,1,1,1,1,1,0,0,0,0,1,1,1,1,1,1,1,1],
-    [1,1,1,1,1,1,1,1,0,0,0,0,1,1,1,1,1,1,1,1],
-    [1,1,1,1,1,1,1,1,0,0,0,0,1,1,1,1,1,1,1,1],
-    [1,1,1,1,1,1,1,1,0,0,0,0,1,1,1,1,1,1,1,1],
-    [1,1,1,1,1,1,1,1,0,0,0,0,1,1,1,1,1,1,1,1],
-    [1,1,1,1,1,1,1,1,0,0,0,0,1,1,1,1,1,1,1,1],
-    [2,2,2,2,2,2,2,2,0,0,0,0,2,2,2,2,2,2,2,2],
-    [2,2,2,2,2,2,2,2,0,0,0,0,2,2,2,3,3,3,2,2],
-    [2,2,2,2,2,2,2,2,0,0,0,0,2,2,2,3,3,3,2,2],
-    [2,2,2,2,2,2,2,2,0,0,0,0,2,2,2,3,3,3,2,2]
-  ];
-
-  let cursors, player, map, layer, moving = false, targetTile = null, camera;
-
   function preload() {
-    // 🔁 Replace these paths with your files
-    this.load.spritesheet(KEYS.tiles, 'assets/tiles.png', { frameWidth: TILE, frameHeight: TILE });
-    this.load.image(KEYS.boyFront, 'assets/boy_front.png');
-    this.load.image(KEYS.boyBack,  'assets/boy_back.png');
-    this.load.image(KEYS.boyLeft,  'assets/boy_left.png');
-    this.load.image(KEYS.boyRight, 'assets/boy_right.png');
+    this.load.image('bg', '../images/background/background.png');
+    this.load.image('player', '../images/characters/shellfin_level_1.png');
   }
 
   function create() {
-    // Create tilemap from data
-    map = this.make.tilemap({ data: worldMap, tileWidth: TILE, tileHeight: TILE });
-    const tileset = map.addTilesetImage(KEYS.tiles);
-    layer = map.createLayer(0, tileset, 0, 0);
-    layer.setScale(SCALE);
+    const { width, height } = this.scale;
 
-    // Mark water (index 1) as colliding
-    layer.setCollision([TILE_INDEX.WATER]);
+    this.add.image(width / 2, height / 2, 'bg')
+      .setDisplaySize(width, height);
 
-    // Player
-    const startX = 10, startY = 2; // tile coords
-    player = this.add.image((startX+0.5)*TILE*SCALE, (startY+0.5)*TILE*SCALE, KEYS.boyFront)
-                     .setOrigin(0.5)
-                     .setScale(SCALE)
-                     .setDepth(10);
+    player = this.physics.add.image(width / 2, height / 2, 'player')
+      .setCollideWorldBounds(true);
 
-    // Set up camera to follow player
-    camera = this.cameras.main;
-    camera.setBounds(0, 0, map.widthInPixels*SCALE, map.heightInPixels*SCALE);
-    camera.startFollow(player, true, 0.2, 0.2);
+    const baseRadius = 60;
+    const thumbRadius = 30;
+    const baseX = 90;
+    const baseY = height - 90;
 
-    cursors = this.input.keyboard.createCursorKeys();
+    joystickBase = this.add.circle(baseX, baseY, baseRadius, 0xffffff, 0.2)
+      .setStrokeStyle(2, 0xffffff, 0.3)
+      .setScrollFactor(0)
+      .setInteractive();
 
-    // Ensure crisp pixels
-    this.game.renderer.pixelArt = true;
+    joystickThumb = this.add.circle(baseX, baseY, thumbRadius, 0xffffff, 0.8)
+      .setScrollFactor(0);
+
+    joystickBase.on('pointerdown', pointer => {
+      joystickPointer = pointer.id;
+      moveThumb(pointer);
+    });
+
+    this.input.on('pointermove', pointer => {
+      if (pointer.id === joystickPointer) {
+        moveThumb(pointer);
+      }
+    });
+
+    this.input.on('pointerup', pointer => {
+      if (pointer.id === joystickPointer) {
+        joystickPointer = null;
+        joystickThumb.x = joystickBase.x;
+        joystickThumb.y = joystickBase.y;
+        joystickVector.set(0, 0);
+      }
+    });
+
+    function moveThumb(pointer) {
+      const dx = pointer.x - joystickBase.x;
+      const dy = pointer.y - joystickBase.y;
+      joystickVector.set(dx, dy);
+      const dist = Math.min(joystickVector.length(), baseRadius);
+      const angle = joystickVector.angle();
+      joystickThumb.x = joystickBase.x + Math.cos(angle) * dist;
+      joystickThumb.y = joystickBase.y + Math.sin(angle) * dist;
+    }
   }
 
   function update(time, delta) {
-    if (moving) return; // Don't accept input mid-move
-
-    let dx = 0, dy = 0, facingKey = null;
-    if (Phaser.Input.Keyboard.JustDown(cursors.left))  { dx = -1; facingKey = KEYS.boyLeft; }
-    else if (Phaser.Input.Keyboard.JustDown(cursors.right)) { dx = 1; facingKey = KEYS.boyRight; }
-    else if (Phaser.Input.Keyboard.JustDown(cursors.up))    { dy = -1; facingKey = KEYS.boyBack; }
-    else if (Phaser.Input.Keyboard.JustDown(cursors.down))  { dy = 1; facingKey = KEYS.boyFront; }
-
-    if (dx === 0 && dy === 0) return;
-
-    const { x:tileX, y:tileY } = worldToTile(player.x, player.y);
-    const nx = tileX + dx;
-    const ny = tileY + dy;
-
-    if (!inBounds(nx, ny)) { // out of map
-      player.setTexture(facingKey); return;
+    if (joystickVector.length() > 0) {
+      const dir = joystickVector.clone().normalize();
+      player.x += dir.x * SPEED * (delta / 1000);
+      player.y += dir.y * SPEED * (delta / 1000);
     }
-
-    const tile = map.getTileAt(nx, ny);
-    if (tile && tile.index === TILE_INDEX.WATER) { // blocked
-      player.setTexture(facingKey); return;
-    }
-
-    player.setTexture(facingKey);
-    moveToTile(nx, ny);
-  }
-
-  function moveToTile(tx, ty) {
-    moving = true;
-    const px = (tx + 0.5) * TILE * SCALE;
-    const py = (ty + 0.5) * TILE * SCALE;
-
-    // Tween to keep movement smooth but grid-locked
-    player.scene.tweens.add({
-      targets: player,
-      x: px,
-      y: py,
-      duration: Math.round((TILE * SCALE) / SPEED * 1000),
-      ease: 'Linear',
-      onComplete: () => { moving = false; }
-    });
-  }
-
-  function worldToTile(wx, wy) {
-    return {
-      x: Math.floor(wx / (TILE*SCALE)),
-      y: Math.floor(wy / (TILE*SCALE))
-    };
-  }
-
-  function inBounds(x, y) {
-    return x >= 0 && y >= 0 && x < map.width && y < map.height;
   }
 })();
 </script>


### PR DESCRIPTION
## Summary
- Replace keyboard tilemap example with free-movement scene
- Add on-screen virtual joystick for touch thumb control
- Load shellfin sprite and ocean backdrop

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68b8f117ad4483299f66f84441234b9f