### PR TITLE
Remove duplicate player sprite in test 2 demo

### DIFF
--- a/test 2/index.html
+++ b/test 2/index.html
@@ -38,8 +38,6 @@
     this.load.image('playerBack', 'assets/swim_shellfin_back.png');
     this.load.image('playerLeft', 'assets/swim_shellfin_left.png');
     this.load.image('playerRight', 'assets/swim_shellfin_right.png');
-    // Load the updated player sprite from the local assets folder
-    this.load.image('player', 'assets/swim_shellfin_front.png');
   }
 
   function create() {
@@ -49,9 +47,6 @@
       .setDisplaySize(width, height);
 
     player = this.physics.add.image(width / 2, height / 2, 'playerFront')
-    player = this.physics.add.image(width / .5, height / .5, 'player')
-      .setCollideWorldBounds(true);
-    player = this.physics.add.image(width / 2, height / 2, 'player')
       .setCollideWorldBounds(true)
       // Ensure the sprite displays at the intended size
       .setDisplaySize(150, 150);


### PR DESCRIPTION
## Summary
- eliminate multiple physics image calls that spawned extra player sprites
- load only directional player sprites needed for joystick demo

## Testing
- `npm test` (fails: ENOENT package.json)

------
https://chatgpt.com/codex/tasks/task_e_68b8f78357408329bcf271f91f07d526