### PR TITLE
Add spacing and icons to test2 action buttons

### DIFF
--- a/test2/index.html
+++ b/test2/index.html
@@ -122,20 +122,16 @@
     // Action buttons
     attackBtn = document.createElement('div');
     attackBtn.className = 'action-btn';
-    attackBtn.style.right = '120px';
+    attackBtn.style.right = '124px';
     attackBtn.style.bottom = '40px';
-    attackBtn.innerHTML = '<img src="assets/attack.svg" alt="attack">';
-    attackBtn.style.right = '110px';
-    attackBtn.style.bottom = '40px';
-    attackBtn.textContent = '🗡️';
+    attackBtn.innerHTML = '<img src="assets/attack.png" alt="attack">';
     document.body.appendChild(attackBtn);
 
     shieldBtn = document.createElement('div');
     shieldBtn.className = 'action-btn';
     shieldBtn.style.right = '40px';
     shieldBtn.style.bottom = '40px';
-    shieldBtn.innerHTML = '<img src="assets/defend.svg" alt="defend">';
-    shieldBtn.textContent = '🛡️';
+    shieldBtn.innerHTML = '<img src="assets/defend.png" alt="defend">';
     document.body.appendChild(shieldBtn);
 
     // Bubble texture for attack


### PR DESCRIPTION
## Summary
- Show attack and defend icons on the action buttons in test2
- Space the action buttons 24px apart for consistent layout

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9f0c9b3388329b9b282ac51b77fce