### PR TITLE
Add create battle UI with dynamic question blocks

### DIFF
--- a/create/index.html
+++ b/create/index.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Create Battle</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <header class="top-bar">
+    <h1 class="text-large">Create Battle</h1>
+    <button class="close" aria-label="Close">&times;</button>
+  </header>
+  <main>
+    <form id="battle-form">
+      <div class="subcard">
+        <label for="battle-name" class="text-large">Battle Name</label>
+        <input type="text" id="battle-name" class="text-small" placeholder="Enter Name" />
+      </div>
+      <div id="questions-container">
+        <section class="question-block subcard" data-index="1">
+          <h2 class="text-large">Question 1</h2>
+          <input type="text" name="question1" class="text-small" placeholder="Enter Question" />
+          <select name="type1" class="question-type text-small">
+            <option value="" disabled selected>Select Category</option>
+            <option value="multiple">Multiple Choice</option>
+            <option value="boolean">True or False</option>
+            <option value="text">Type Answer</option>
+          </select>
+          <div class="answer-fields"></div>
+        </section>
+      </div>
+      <button type="button" id="add-question" class="text-medium"><span class="plus">+</span>Add Question</button>
+      <button type="submit" class="submit-btn text-medium">Submit</button>
+    </form>
+  </main>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/create/script.js
+++ b/create/script.js
@@ -1,0 +1,66 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const addQuestionBtn = document.getElementById('add-question');
+  const questionsContainer = document.getElementById('questions-container');
+  let questionCount = 1;
+
+  addQuestionBtn.addEventListener('click', () => {
+    questionCount++;
+    const block = createQuestionBlock(questionCount);
+    questionsContainer.appendChild(block);
+  });
+
+  questionsContainer.addEventListener('change', (e) => {
+    if (e.target.classList.contains('question-type')) {
+      const block = e.target.closest('.question-block');
+      renderAnswerFields(block, e.target.value);
+    }
+  });
+
+  function createQuestionBlock(index) {
+    const section = document.createElement('section');
+    section.className = 'question-block subcard';
+    section.dataset.index = index;
+    section.innerHTML = `
+      <h2 class="text-large">Question ${index}</h2>
+      <input type="text" name="question${index}" class="text-small" placeholder="Enter Question" />
+      <select name="type${index}" class="question-type text-small">
+        <option value="" disabled selected>Select Category</option>
+        <option value="multiple">Multiple Choice</option>
+        <option value="boolean">True or False</option>
+        <option value="text">Type Answer</option>
+      </select>
+      <div class="answer-fields"></div>
+    `;
+    return section;
+  }
+
+  function renderAnswerFields(block, type) {
+    const container = block.querySelector('.answer-fields');
+    container.innerHTML = '';
+    const index = block.dataset.index;
+    if (type === 'multiple') {
+      for (let i = 1; i <= 4; i++) {
+        const input = document.createElement('input');
+        input.type = 'text';
+        input.placeholder = `Option ${i}`;
+        input.name = `q${index}option${i}`;
+        input.className = 'text-small';
+        container.appendChild(input);
+      }
+    } else if (type === 'boolean') {
+      const trueLabel = document.createElement('label');
+      trueLabel.innerHTML = `<input type="radio" name="q${index}bool" value="true"> True`;
+      const falseLabel = document.createElement('label');
+      falseLabel.innerHTML = `<input type="radio" name="q${index}bool" value="false"> False`;
+      container.appendChild(trueLabel);
+      container.appendChild(falseLabel);
+    } else if (type === 'text') {
+      const input = document.createElement('input');
+      input.type = 'text';
+      input.placeholder = 'Type answer';
+      input.name = `q${index}answer`;
+      input.className = 'text-small';
+      container.appendChild(input);
+    }
+  }
+});

--- a/create/style.css
+++ b/create/style.css
@@ -1,0 +1,142 @@
+* {
+  box-sizing: border-box;
+}
+
+:root {
+  --font-rounded: 'Arial Rounded MT', Arial, sans-serif;
+}
+
+.text-large {
+  font-family: var(--font-rounded);
+  font-size: 24px;
+  letter-spacing: -0.02em;
+}
+
+.text-medium {
+  font-family: var(--font-rounded);
+  font-size: 20px;
+  letter-spacing: -0.02em;
+}
+
+.text-small {
+  font-family: var(--font-rounded);
+  font-size: 16px;
+  letter-spacing: -0.02em;
+}
+
+body {
+  margin: 0;
+  font-family: var(--font-rounded);
+  background: #f3f5f9;
+  color: #333;
+}
+
+.top-bar {
+  background: #001f8b;
+  color: #fff;
+  padding: 20px 0;
+  text-align: center;
+  position: relative;
+}
+
+.top-bar .close {
+  position: absolute;
+  right: 20px;
+  top: 50%;
+  transform: translateY(-50%);
+  background: none;
+  border: none;
+  color: #fff;
+  font-size: 32px;
+  cursor: pointer;
+}
+main {
+  display: flex;
+  justify-content: center;
+  padding: 40px 20px;
+}
+form {
+  background: #fff;
+  padding: 30px;
+  width: 100%;
+  max-width: 500px;
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+}
+
+label {
+  display: block;
+  margin-bottom: 8px;
+  font-weight: 600;
+}
+
+input[type="text"],
+select {
+  width: 100%;
+  padding: 10px;
+  margin-bottom: 20px;
+  border: 1px solid #D6D6D6;
+  border-radius: 6px;
+  background: #fff;
+  font-family: var(--font-rounded);
+  font-size: 16px;
+  letter-spacing: -0.02em;
+}
+
+.subcard {
+  background: #F4F6FA;
+  border-radius: 8px;
+  padding: 40px;
+  margin-bottom: 20px;
+}
+
+.question-block {
+  margin-top: 30px;
+}
+
+#add-question {
+  background: none;
+  border: none;
+  color: #0070f3;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  margin: 20px auto;
+}
+
+#add-question .plus {
+  display: inline-block;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: #0070f3;
+  color: #fff;
+  line-height: 20px;
+  text-align: center;
+}
+
+.submit-btn {
+  background: #0053f0;
+  border: none;
+  color: #fff;
+  width: 100%;
+  padding: 15px;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.answer-fields input[type="text"] {
+  margin-bottom: 10px;
+}
+
+.answer-fields label {
+  display: inline-flex;
+  align-items: center;
+  margin-right: 10px;
+  font-weight: normal;
+  font-family: var(--font-rounded);
+  font-size: 16px;
+  letter-spacing: -0.02em;
+}


### PR DESCRIPTION
## Summary
- Add reusable Arial Rounded typography classes for 24/20/16px text
- Style battle name and question blocks as padded subcards and center add-question control with a plus icon
- Apply type styles to dynamically generated fields and buttons
- Fix true/false radio options to line up horizontally

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68befed831648329acdcbea0da1bd097