### PR TITLE
Use localStorage for battles and add reset option

### DIFF
--- a/create/home.js
+++ b/create/home.js
@@ -1,54 +1,84 @@
 document.addEventListener('DOMContentLoaded', () => {
   const list = document.getElementById('battle-list');
   const createBtn = document.getElementById('create-battle');
+  const resetBtn = document.getElementById('reset-battles');
 
   createBtn.addEventListener('click', () => {
     window.location.href = 'create.html';
   });
 
-  fetch('../data/battles.json')
-    .then(res => res.json())
-    .then(battles => {
-      if (!Array.isArray(battles)) return;
+  const renderBattles = battles => {
+    if (!Array.isArray(battles)) return;
 
-      battles.forEach(battle => {
-        // Guard against malformed battle data which previously caused the page
-        // to fail rendering any battles.
-        const questionCount = Array.isArray(battle.questions)
-          ? battle.questions.length
-          : 0;
+    battles.forEach(battle => {
+      // Guard against malformed battle data which previously caused the page
+      // to fail rendering any battles.
+      const questionCount = Array.isArray(battle.questions)
+        ? battle.questions.length
+        : 0;
 
-        const item = document.createElement('div');
-        item.className = 'battle-card';
+      const item = document.createElement('div');
+      item.className = 'battle-card';
 
-        const info = document.createElement('div');
-        info.className = 'battle-info';
+      const info = document.createElement('div');
+      info.className = 'battle-info';
 
-        const name = document.createElement('h2');
-        name.className = 'battle-name';
-        name.textContent = battle.name;
-        info.appendChild(name);
+      const name = document.createElement('h2');
+      name.className = 'battle-name';
+      name.textContent = battle.name;
+      info.appendChild(name);
 
-        const count = document.createElement('p');
-        count.className = 'battle-count';
-        count.textContent = `${questionCount} Questions`;
-        info.appendChild(count);
+      const count = document.createElement('p');
+      count.className = 'battle-count';
+      count.textContent = `${questionCount} Questions`;
+      info.appendChild(count);
 
-        const edit = document.createElement('button');
-        edit.className = 'submit-btn text-small';
-        edit.style.width = 'auto';
-        edit.textContent = 'Edit';
-        edit.addEventListener('click', () => {
-          window.location.href = `create.html?id=${battle.id}`;
-        });
-
-        item.appendChild(info);
-        item.appendChild(edit);
-        list.appendChild(item);
+      const edit = document.createElement('button');
+      edit.className = 'submit-btn text-small';
+      edit.style.width = 'auto';
+      edit.textContent = 'Edit';
+      edit.addEventListener('click', () => {
+        window.location.href = `create.html?id=${battle.id}`;
       });
-    })
-    .catch(() => {
-      // If the request fails, avoid leaving the homepage blank.
-      list.innerHTML = '<p class="text-small">No battles found.</p>';
+
+      item.appendChild(info);
+      item.appendChild(edit);
+      list.appendChild(item);
     });
+  };
+
+  const loadBattlesFromFetch = () => {
+    fetch('../data/battles.json')
+      .then(res => res.json())
+      .then(battles => {
+        if (!Array.isArray(battles)) return;
+        localStorage.setItem('battles', JSON.stringify(battles));
+        renderBattles(battles);
+      })
+      .catch(() => {
+        // If the request fails, avoid leaving the homepage blank.
+        list.innerHTML = '<p class="text-small">No battles found.</p>';
+      });
+  };
+
+  try {
+    const stored = localStorage.getItem('battles');
+    if (stored) {
+      const battles = JSON.parse(stored);
+      renderBattles(battles);
+    } else {
+      loadBattlesFromFetch();
+    }
+  } catch (err) {
+    // If parsing fails, reset the storage and fall back to fetch.
+    localStorage.removeItem('battles');
+    loadBattlesFromFetch();
+  }
+
+  if (resetBtn) {
+    resetBtn.addEventListener('click', () => {
+      localStorage.removeItem('battles');
+      window.location.reload();
+    });
+  }
 });

--- a/create/index.html
+++ b/create/index.html
@@ -9,7 +9,10 @@
   <body>
     <div style="padding:40px 80px; width:100%; box-sizing:border-box;">
       <h1 class="text-large" style="margin-bottom:40px;">Welcome, Josh</h1>
-        <button id="create-battle" class="submit-btn text-medium" style="width:auto; margin-bottom:40px;">Create Battle</button>
+        <div style="margin-bottom:40px;">
+          <button id="create-battle" class="submit-btn text-medium" style="width:auto;">Create Battle</button>
+          <button id="reset-battles" class="submit-btn text-medium" style="width:auto; margin-left:10px;">Reset Battles</button>
+        </div>
         <div id="battle-list"></div>
       </div>
       <script src="./home.js"></script>


### PR DESCRIPTION
## Summary
- Load battles from `localStorage` if available, otherwise fetch default data and persist it.
- Add reset button to clear stored battles and reload defaults.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bf81f55fa0832985dd595379d09f16