### PR TITLE
Add inline validation and edit delete option to battle forms

### DIFF
--- a/create/style.css
+++ b/create/style.css
@@ -285,6 +285,32 @@ input[type="text"]::placeholder {
     pointer-events: none;
   }
 
+  /* Validation error styles */
+  .error {
+    border: 2px solid #E20000 !important;
+  }
+
+  .error-message {
+    color: #E20000;
+    margin-top: 16px;
+  }
+
+  .answers-list.error {
+    padding: 16px;
+    border-radius: 6px;
+  }
+
+  .delete-btn {
+    background: #fff;
+    border: 2px solid #E20000;
+    color: #E20000;
+    width: 100%;
+    padding: 15px;
+    border-radius: 6px;
+    cursor: pointer;
+    margin-top: 16px;
+  }
+
 @media (max-width: 600px) {
   .top-bar {
     padding: 15px 0;


### PR DESCRIPTION
## Summary
- show inline validation errors on create/edit battle forms
- scroll to first field error during form submission
- add white 'Delete Battle' button to edit flow

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c056e81b488329932807881a797f7c