### PR TITLE
Refine battle home UI and validation

### DIFF
--- a/create/home.js
+++ b/create/home.js
@@ -1,7 +1,6 @@
 document.addEventListener('DOMContentLoaded', () => {
   const list = document.getElementById('battle-list');
   const createBtn = document.getElementById('create-battle');
-  const resetBtn = document.getElementById('reset-battles');
 
   createBtn.addEventListener('click', () => {
     window.location.href = 'create.html';
@@ -43,7 +42,7 @@ document.addEventListener('DOMContentLoaded', () => {
         });
 
         const edit = document.createElement('button');
-        edit.className = 'submit-btn text-small';
+        edit.className = 'submit-btn text-small edit-btn';
         edit.style.width = 'auto';
         edit.textContent = 'Edit';
         edit.addEventListener('click', () => {
@@ -79,12 +78,4 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   loadBattles();
-
-  if (resetBtn) {
-    resetBtn.addEventListener('click', async () => {
-      if (!window.supabaseClient) return;
-      await window.supabaseClient.from('battles').delete().neq('id', 0);
-      list.innerHTML = '';
-    });
-  }
 });

--- a/create/index.html
+++ b/create/index.html
@@ -11,7 +11,6 @@
       <h1 class="text-large" style="margin-bottom:40px;">Welcome, Josh</h1>
         <div style="margin-bottom:40px;">
           <button id="create-battle" class="submit-btn text-medium" style="width:auto;">Create Battle</button>
-          <button id="reset-battles" class="submit-btn text-medium" style="width:auto; margin-left:10px;">Reset Battles</button>
         </div>
         <div id="battle-list"></div>
       </div>

--- a/create/script.js
+++ b/create/script.js
@@ -80,7 +80,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
     function removeError(field) {
       field.classList.remove('error');
-      const msg = field.nextElementSibling;
+      const container = field.classList.contains('answer-input') ? field.closest('.answer-row') : field;
+      const msg = container.nextElementSibling;
       if (msg && msg.classList.contains('error-message')) {
         msg.remove();
       }
@@ -380,13 +381,14 @@ document.addEventListener('DOMContentLoaded', () => {
     form.querySelectorAll('.error-message').forEach(el => el.remove());
   }
 
-  function markError(el) {
-    el.classList.add('error');
-    const msg = document.createElement('div');
-    msg.className = 'error-message text-small';
-    msg.textContent = 'Required Field';
-    el.insertAdjacentElement('afterend', msg);
-  }
+    function markError(el, message = 'Required Field') {
+      el.classList.add('error');
+      const container = el.classList.contains('answer-input') ? el.closest('.answer-row') : el;
+      const msg = document.createElement('div');
+      msg.className = 'error-message text-small';
+      msg.textContent = message;
+      container.insertAdjacentElement('afterend', msg);
+    }
 
   function validateForm() {
     clearErrors();
@@ -423,13 +425,13 @@ document.addEventListener('DOMContentLoaded', () => {
         const selected = block.querySelectorAll('.correct-btn.selected');
         if (selected.length === 0) {
           const list = block.querySelector('.answers-list');
-          markError(list);
+          markError(list, 'Select a Correct Answer');
           firstError = firstError || list;
         }
       } else if (type === 'boolean') {
         if (block.querySelectorAll('.correct-btn.selected').length !== 1) {
           const list = block.querySelector('.answers-list');
-          markError(list);
+          markError(list, 'Select a Correct Answer');
           firstError = firstError || list;
         }
       } else if (type === 'text') {

--- a/create/style.css
+++ b/create/style.css
@@ -27,6 +27,10 @@ html, body {
   font-weight:100;
 }
 
+h1.text-large {
+  font-size: 40px;
+}
+
 .text-medium {
   font-family: var(--font-rounded);
   font-size: 20px;
@@ -145,10 +149,11 @@ input[type="text"]::placeholder {
   .battle-info {
     display: flex;
     flex-direction: column;
+    gap: 8px;
   }
 
   .battle-name {
-    font-size: 36px;
+    font-size: 32px;
     color: #272B34;
     margin: 0;
   }
@@ -235,6 +240,16 @@ input[type="text"]::placeholder {
 
   .submit-btn:hover {
     background: #004BD8;
+  }
+
+  .edit-btn {
+    background: #fff;
+    border: 2px solid #006AFF;
+    color: #006AFF;
+  }
+
+  .edit-btn:hover {
+    background: #fff;
   }
 
   .answers-label {


### PR DESCRIPTION
## Summary
- Remove "Reset Battles" control from the creator home page and update typography for titles and battle cards
- Style "Edit" action as white button with blue outline
- Improve validation: avoid checkbox shift on error and show "Select a Correct Answer" when no correct option picked

## Testing
- `npm test` *(fails: ENOENT, could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c073d831bc8329a4dc252c0a01a0eb