### PR TITLE
Fix battle view not initiating

### DIFF
--- a/js/battle.js
+++ b/js/battle.js
@@ -88,7 +88,9 @@ document.addEventListener('DOMContentLoaded', () => {
     const starts = Object.values(hero.levels).map((l) => Number(l.start));
     maxLevelStart = Math.max(...starts);
 
-    
+    // Show the battle view once data is ready
+    game.style.display = 'none';
+    battleDiv.style.display = 'block';
   }
 
   document.addEventListener('assets-loaded', loadData);


### PR DESCRIPTION
## Summary
- Show battle view automatically once character data loads so battle begins after clicking View

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c087dc2b6083299686cf80516122d9