### PR TITLE
Add lesson plan upload flow

### DIFF
--- a/css/upload.css
+++ b/css/upload.css
@@ -1,0 +1,64 @@
+main {
+  display: flex;
+  justify-content: center;
+  padding: 40px 20px;
+}
+
+.upload-card {
+  background: #fff;
+  padding: 40px;
+  width: 100%;
+  max-width: 600px;
+  border-radius: 8px;
+  box-shadow: 0 4px 80px rgba(0,0,0,0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 40px;
+}
+
+.drop-area {
+  border: 2px dashed #D6D6D6;
+  border-radius: 8px;
+  height: 200px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  cursor: pointer;
+}
+
+.upload-placeholder img {
+  width: 60px;
+  margin-bottom: 16px;
+}
+
+.buttons {
+  display: flex;
+  justify-content: space-between;
+  gap: 20px;
+}
+
+.buttons button {
+  flex: 1;
+  height: 56px;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+#skip-btn {
+  background: #fff;
+  border: 1px solid #D6D6D6;
+  color: #272B34;
+}
+
+#submit-btn {
+  background: #000666;
+  color: #fff;
+}
+
+#submit-btn:disabled {
+  background: #9C9C9C;
+  cursor: not-allowed;
+}

--- a/html/upload.html
+++ b/html/upload.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Create Battle</title>
+  <link rel="stylesheet" href="../css/create.css" />
+  <link rel="stylesheet" href="../css/upload.css" />
+</head>
+<body>
+  <header class="top-bar">
+    <h1 class="text-large">Create Battle</h1>
+    <button class="close" aria-label="Close">
+      <img src="../images/create/close.svg" alt="Close" />
+    </button>
+  </header>
+  <main>
+    <form id="upload-form" class="upload-card">
+      <label for="file-input" class="drop-area">
+        <input id="file-input" type="file" accept=".pdf,.doc,.docx" hidden />
+        <div class="upload-placeholder">
+          <img src="../images/create/upload.svg" alt="Upload" />
+          <p class="text-medium">Click to Upload</p>
+          <p class="text-small">Supported formats: PDF, DOC</p>
+        </div>
+      </label>
+      <div class="buttons">
+        <button type="button" id="skip-btn" class="text-medium">Skip</button>
+        <button type="submit" id="submit-btn" class="text-medium" disabled>Submit</button>
+      </div>
+    </form>
+  </main>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.4.120/pdf.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.4.120/pdf.worker.min.js"></script>
+  <script src="https://unpkg.com/mammoth@1.4.23/mammoth.browser.min.js"></script>
+  <script src="../js/upload.js"></script>
+</body>
+</html>

--- a/images/create/upload.svg
+++ b/images/create/upload.svg
@@ -1,0 +1,5 @@
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M32 4V44" stroke="#9C9C9C" stroke-width="4" stroke-linecap="round"/>
+  <path d="M20 16L32 4L44 16" stroke="#9C9C9C" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+  <rect x="16" y="44" width="32" height="16" stroke="#9C9C9C" stroke-width="4" stroke-linejoin="round"/>
+</svg>

--- a/js/create.js
+++ b/js/create.js
@@ -445,6 +445,25 @@ document.addEventListener('DOMContentLoaded', () => {
     return firstError;
   }
 
+  const uploaded = localStorage.getItem('uploadedQuestions');
+  if (uploaded && !battleId) {
+    const parsed = JSON.parse(uploaded);
+    questionsContainer.innerHTML = '';
+    parsed.forEach((q, idx) => {
+      const block = createQuestionBlock(idx + 1);
+      questionsContainer.appendChild(block);
+      const input = block.querySelector('input[type="text"]');
+      input.value = q.question || '';
+      const select = block.querySelector('.question-type');
+      select.value = 'text';
+      select.style.color = '#272B34';
+      renderAnswerFields(block, 'text');
+      const answerInput = block.querySelector('.answer-input');
+      if (answerInput) answerInput.value = q.answer || '';
+    });
+    localStorage.removeItem('uploadedQuestions');
+  }
+
   function populateForm(battle) {
     document.getElementById('battle-name').value = battle.name;
     questionsContainer.innerHTML = '';

--- a/js/home.js
+++ b/js/home.js
@@ -3,7 +3,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const createBtn = document.getElementById('create-battle');
 
   createBtn.addEventListener('click', () => {
-    window.location.href = 'create.html';
+    window.location.href = 'upload.html';
   });
 
   const renderBattles = (battles) => {

--- a/js/upload.js
+++ b/js/upload.js
@@ -1,0 +1,69 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const fileInput = document.getElementById('file-input');
+  const submitBtn = document.getElementById('submit-btn');
+  const skipBtn = document.getElementById('skip-btn');
+  const closeBtn = document.querySelector('.close');
+
+  document.querySelector('.drop-area').addEventListener('click', () => fileInput.click());
+
+  fileInput.addEventListener('change', () => {
+    submitBtn.disabled = fileInput.files.length === 0;
+  });
+
+  skipBtn.addEventListener('click', () => {
+    window.location.href = 'create.html';
+  });
+
+  closeBtn.addEventListener('click', () => {
+    window.location.href = 'index.html';
+  });
+
+  document.getElementById('upload-form').addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const file = fileInput.files[0];
+    if (!file) return;
+    try {
+      const text = await extractText(file);
+      const questions = parseQA(text);
+      localStorage.setItem('uploadedQuestions', JSON.stringify(questions));
+      window.location.href = 'create.html';
+    } catch (err) {
+      console.error('Failed to parse file', err);
+      alert('Unable to parse file.');
+    }
+  });
+
+  async function extractText(file) {
+    const arrayBuffer = await file.arrayBuffer();
+    if (file.type === 'application/pdf') {
+      const pdf = await pdfjsLib.getDocument({ data: arrayBuffer }).promise;
+      let text = '';
+      for (let i = 1; i <= pdf.numPages; i++) {
+        const page = await pdf.getPage(i);
+        const content = await page.getTextContent();
+        text += content.items.map(item => item.str).join(' ') + '\n';
+      }
+      return text;
+    } else {
+      const result = await mammoth.extractRawText({ arrayBuffer });
+      return result.value;
+    }
+  }
+
+  function parseQA(text) {
+    const lines = text.split(/\r?\n/);
+    const out = [];
+    let current = null;
+    lines.forEach(line => {
+      const q = line.match(/^(?:Q\d*[:.\-]|Question\s*\d*[:.\-])\s*(.+)/i);
+      const a = line.match(/^(?:A\d*[:.\-]|Answer\s*\d*[:.\-])\s*(.+)/i);
+      if (q) {
+        current = { question: q[1].trim(), answer: '' };
+        out.push(current);
+      } else if (a && current) {
+        current.answer = a[1].trim();
+      }
+    });
+    return out;
+  }
+});


### PR DESCRIPTION
## Summary
- add upload page to convert PDF or DOC lessons into battle questions
- parse documents client side and store results for battle creation
- wire create and home pages to support uploaded question data

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c098b360248329ba3fbd5f745fbb38