### PR TITLE
Enhance upload page with drag-and-drop preview and improved parsing

### DIFF
--- a/css/upload.css
+++ b/css/upload.css
@@ -28,6 +28,11 @@ main {
   cursor: pointer;
 }
 
+.drop-area.dragover {
+  border-color: #000666;
+  background: #F0F4FF;
+}
+
 .upload-placeholder img {
   width: 60px;
   margin-bottom: 16px;
@@ -61,4 +66,16 @@ main {
 #submit-btn:disabled {
   background: #9C9C9C;
   cursor: not-allowed;
+}
+
+.preview {
+  border-top: 1px solid #D6D6D6;
+  padding-top: 20px;
+  max-height: 150px;
+  overflow-y: auto;
+  text-align: left;
+}
+
+.hidden {
+  display: none;
 }

--- a/html/upload.html
+++ b/html/upload.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Create Battle</title>
+  <title>Upload Questions</title>
   <link rel="stylesheet" href="../css/create.css" />
   <link rel="stylesheet" href="../css/upload.css" />
 </head>
@@ -17,13 +17,14 @@
   <main>
     <form id="upload-form" class="upload-card">
       <label for="file-input" class="drop-area">
-        <input id="file-input" type="file" accept=".pdf,.doc,.docx" hidden />
+        <input id="file-input" type="file" accept=".pdf,.doc,.docx,.txt" hidden />
         <div class="upload-placeholder">
           <img src="../images/create/upload.svg" alt="Upload" />
-          <p class="text-medium">Click to Upload</p>
-          <p class="text-small">Supported formats: PDF, DOC</p>
+          <p class="text-medium">Click or Drag a File</p>
+          <p class="text-small">Supported formats: PDF, DOC, TXT</p>
         </div>
       </label>
+      <div id="preview" class="preview text-small hidden"></div>
       <div class="buttons">
         <button type="button" id="skip-btn" class="text-medium">Skip</button>
         <button type="submit" id="submit-btn" class="text-medium" disabled>Submit</button>


### PR DESCRIPTION
## Summary
- Add drag-and-drop uploads with content preview and support for TXT files on the upload page.
- Style new preview area and drag-over state for clearer user feedback.
- Expand client script to extract text, parse multi-line Q&A, and alert on import results.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c09bc96ffc83298a6edef1fadcbeba