### PR TITLE
Add reusable level message screen

### DIFF
--- a/css/level.css
+++ b/css/level.css
@@ -1,0 +1,77 @@
+body {
+  margin: 0;
+  height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: url('../images/background/background.png') no-repeat center/cover;
+  font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
+}
+
+.level-message {
+  background: #fff;
+  border-radius: 8px;
+  padding: 24px;
+  width: 100%;
+  max-width: 400px;
+  box-sizing: border-box;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 24px;
+  animation: pop-in 0.3s ease-out;
+}
+
+.level-message .level-title {
+  font-size: 20px;
+  color: #9C9C9C;
+  margin: 0;
+}
+
+.level-message .progress-bar {
+  width: 100%;
+  height: 16px;
+  background: #F4F6FA;
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.level-message .progress-fill {
+  height: 100%;
+  width: 0%;
+  background: #006AFF;
+  border-radius: 4px;
+}
+
+.level-message .math-type {
+  font-size: 32px;
+  color: #272B34;
+  margin: 0;
+}
+
+.level-message .enemy-image {
+  width: 100%;
+  max-width: 200px;
+  height: auto;
+}
+
+.btn-primary {
+  width: 100%;
+  height: 56px;
+  background: #006AFF;
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  font-size: 20px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+@keyframes pop-in {
+  0% { transform: scale(0.8); opacity: 0; }
+  80% { transform: scale(1.05); opacity: 1; }
+  100% { transform: scale(1); opacity: 1; }
+}

--- a/data/levels.json
+++ b/data/levels.json
@@ -1,0 +1,11 @@
+{
+  "levels": [
+    {
+      "id": 1,
+      "math": "Addition",
+      "enemySprite": "battle/monster_battle.png",
+      "background": "background/background.png",
+      "progress": 0.0
+    }
+  ]
+}

--- a/html/level.html
+++ b/html/level.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Level</title>
+  <link rel="stylesheet" href="../css/level.css" />
+</head>
+<body>
+  <div class="level-message">
+    <p class="level-title level-number">Level 1</p>
+    <div class="progress-bar"><div class="progress-fill"></div></div>
+    <p class="math-type">Addition</p>
+    <img class="enemy-image" src="../images/battle/monster_battle.png" alt="Enemy" />
+    <button class="btn-primary battle-btn">Battle</button>
+  </div>
+  <script src="../js/level.js"></script>
+</body>
+</html>

--- a/js/level.js
+++ b/js/level.js
@@ -1,0 +1,18 @@
+document.addEventListener('DOMContentLoaded', async () => {
+  try {
+    const res = await fetch('../data/levels.json');
+    const data = await res.json();
+    const current = data.levels[0];
+
+    document.querySelector('.level-number').textContent = `Level ${current.id}`;
+    document.querySelector('.math-type').textContent = current.math;
+    document.querySelector('.enemy-image').src = `../images/${current.enemySprite}`;
+    document.querySelector('.progress-fill').style.width = `${current.progress * 100}%`;
+  } catch (e) {
+    console.error('Failed to load level data', e);
+  }
+
+  document.querySelector('.battle-btn').addEventListener('click', () => {
+    window.location.href = 'battle.html';
+  });
+});


### PR DESCRIPTION
## Summary
- Add standalone level message page with centered popup, progress bar and battle button
- Introduce reusable CSS styles for progress bar, button and pop-in animation
- Load level data from new `levels.json` and navigate to battle screen

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1a4e667b88329ad6d26f64ae45529