### PR TITLE
Simplify battle sequence to question-result loop

### DIFF
--- a/css/battle.css
+++ b/css/battle.css
@@ -110,3 +110,47 @@
   50% { transform: translateX(-50px); }
   100% { transform: translateX(0); }
 }
+
+#level-message {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.3s ease;
+  z-index: 30;
+}
+
+#level-message.show {
+  opacity: 1;
+  visibility: visible;
+}
+
+#level-message .content {
+  background: #fff;
+  padding: 24px;
+  border-radius: 8px;
+  text-align: center;
+}
+
+#level-message .content p {
+  font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
+  font-size: 24px;
+  margin: 0 0 16px;
+}
+
+#level-message .content button {
+  background: #006AFF;
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  padding: 12px 24px;
+  font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
+  font-size: 18px;
+}

--- a/css/question.css
+++ b/css/question.css
@@ -23,9 +23,9 @@
 
 #question h1 {
   font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
-  font-size: 14px;
-  color: #858585;
-  margin: 0 0 8px;
+  font-size: 16px;
+  color: #888888;
+  margin: 8px 0;
 }
 
 #question p {
@@ -55,16 +55,81 @@
 #question .progress-bar {
   width: 100%;
   height: 16px;
-  background: #F6F6F6;
+  background: #F4F6FA;
   border-radius: 4px;
   overflow: hidden;
-  margin-bottom: 16px;
+  margin-bottom: 8px;
 }
 
 #question .progress-fill {
   width: 0%;
   height: 100%;
   background: #006AFF;
+}
+
+#question .streak-label {
+  font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
+  font-size: 16px;
+  color: #006AFF;
+  margin-top: 4px;
+  align-self: flex-end;
+  opacity: 0;
+  transform: scale(0.8);
+}
+
+#question .streak-label.show {
+  animation: streak-pop 0.6s forwards;
+}
+
+@keyframes streak-pop {
+  0% { opacity: 0; transform: scale(0.8); }
+  50% { opacity: 1; transform: scale(1.1); }
+  100% { opacity: 0; transform: scale(1); }
+}
+
+#question .status {
+  display: flex;
+  width: 100%;
+  justify-content: space-between;
+  margin: 8px 0 16px;
+}
+
+#question .status .stat {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 20px;
+  color: #006AFF;
+}
+
+#question .status .stat img {
+  width: 24px;
+  height: 24px;
+}
+
+#question .status .stat .increase {
+  position: absolute;
+  top: -10px;
+  right: -10px;
+  background: #FFAE00;
+  color: #006AFF;
+  font-size: 20px;
+  padding-left: 14px;
+  padding-right: 14px;
+  border-radius: 100%;
+  opacity: 0;
+  transform: scale(0.5);
+}
+
+#question .status .stat .increase.show {
+  animation: increase-pop 0.6s forwards;
+}
+
+@keyframes increase-pop {
+  0% { opacity: 0; transform: scale(0.5); }
+  50% { opacity: 1; transform: scale(1.2); }
+  100% { opacity: 0; transform: scale(1); }
 }
 
 #question .choices {

--- a/html/battle.html
+++ b/html/battle.html
@@ -28,42 +28,24 @@
       <div class="hp-bar"><div class="hp-fill"></div></div>
     </div>
   </div>
-  <div id="overlay"></div>
-  <div id="message">
-    <div class="generic-content">
-      <img src="../images/message/shellfin_message.png" alt="Shellfin avatar" />
-      <p>Hi! I’m Shellfin. I live on the reef, but monsters have taken over and I need you help!</p>
-      <button type="button">Continue</button>
-    </div>
-    <div class="win-content">
-      <h1 class="hero-name">Mission Complete</h1>
-      <div class="stats">
-        <div class="stat-box progress-box">
-          <p class="progress-label">Experience</p>
-          <div class="progress-bar">
-            <div class="progress-fill"></div>
-            <div class="level-up-badge">Level<br />Up</div>
-          </div>
-        </div>
-        <div class="stat-box">
-          <p class="label">Accuracy</p>
-          <div class="value"><span class="attack"></span></div>
-        </div>
-        <div class="stat-box">
-          <p class="label">Speed</p>
-          <div class="value"><span class="health"></span></div>
-          <div class="value"><span class="attack"></span></div>
-        </div>
-      </div>
-      <button type="button">Continue</button>
-    </div>
-  </div>
     <div id="question">
       <div class="progress-bar"><div class="progress-fill"></div></div>
-      <h1></h1>
+      <div class="streak-label"></div>
+      <div class="status">
+        <div class="stat attack"><img src="../images/question/sword.png" alt="Attack" /><span class="value">0</span><div class="increase"></div></div>
+        <div class="stat health"><img src="../images/question/shield.png" alt="Health" /><span class="value">0</span><div class="increase"></div></div>
+        <div class="stat gem"><img src="../images/question/gem.png" alt="Gem" /><span class="value">0</span><div class="increase"></div></div>
+      </div>
+      <h1>Question</h1>
       <p></p>
       <div class="choices"></div>
-      <button type="button">Answer</button>
+      <button type="button">Submit</button>
+    </div>
+    <div id="level-message">
+      <div class="content">
+        <p></p>
+        <button type="button">try again</button>
+      </div>
     </div>
       <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
       <script src="../js/supabaseClient.js"></script>

--- a/js/battle.js
+++ b/js/battle.js
@@ -1,478 +1,190 @@
 document.addEventListener('DOMContentLoaded', () => {
-  const message = document.getElementById('message');
-  const overlay = document.getElementById('overlay');
-  const monster = document.getElementById('battle-monster');
-  const shellfin = document.getElementById('battle-shellfin');
-  const monsterStats = document.getElementById('monster-stats');
-  const shellfinStats = document.getElementById('shellfin-stats');
-  const monsterName = monsterStats.querySelector('.name');
-  const monsterHpFill = monsterStats.querySelector('.hp-fill');
-  const shellfinName = shellfinStats.querySelector('.name');
-  const shellfinHpFill = shellfinStats.querySelector('.hp-fill');
-  const genericContent = message.querySelector('.generic-content');
-  const genericImg = genericContent.querySelector('img');
-  const genericP = genericContent.querySelector('p');
-  const winContent = message.querySelector('.win-content');
-  const button = genericContent.querySelector('button');
-  const heroNameDisplay = winContent.querySelector('.hero-name');
-  const attackDisplay = winContent.querySelector('.attack');
-  const healthDisplay = winContent.querySelector('.health');
-  const xpFill = winContent.querySelector('.progress-fill');
-  const levelUpBadge = winContent.querySelector('.level-up-badge');
-  const claimButton = winContent.querySelector('button');
+  const monsterImg = document.getElementById('battle-monster');
+  const heroImg = document.getElementById('battle-shellfin');
+  const monsterHpFill = document.querySelector('#monster-stats .hp-fill');
+  const heroHpFill = document.querySelector('#shellfin-stats .hp-fill');
+  const monsterNameEl = document.querySelector('#monster-stats .name');
+  const heroNameEl = document.querySelector('#shellfin-stats .name');
+
   const questionBox = document.getElementById('question');
-  const questionHeading = questionBox.querySelector('h1');
   const questionText = questionBox.querySelector('p');
-  const choices = questionBox.querySelector('.choices');
+  const choicesEl = questionBox.querySelector('.choices');
+  const headingEl = questionBox.querySelector('h1');
   const progressFill = questionBox.querySelector('.progress-fill');
-  const questionButton = questionBox.querySelector('button');
-  const game = document.getElementById('game');
-  const introMonster = document.getElementById('monster');
-  const introShellfin = document.getElementById('shellfin');
-  const battleDiv = document.getElementById('battle');
+  const streakLabel = questionBox.querySelector('.streak-label');
+  const attackVal = questionBox.querySelector('.attack .value');
+  const healthVal = questionBox.querySelector('.health .value');
+  const gemVal = questionBox.querySelector('.gem .value');
+  const attackInc = questionBox.querySelector('.attack .increase');
+  const healthInc = questionBox.querySelector('.health .increase');
+  const gemInc = questionBox.querySelector('.gem .increase');
 
+  const levelMessage = document.getElementById('level-message');
+  const levelText = levelMessage.querySelector('p');
+  const levelButton = levelMessage.querySelector('button');
+
+  const STREAK_GOAL = 10;
   let questions = [];
-  let totalQuestions = 0;
   let currentQuestion = 0;
-  let hero;
-  let foe;
-  let maxLevelStart = 0;
-  let correctAnswers = 0;
-  let answeredQuestions = 0;
-  let startTime;
-  let endTime;
-  let missionExperience = 0;
+  let streak = 0;
 
-  const ATTACK_DELAY_MS = 1200;
+  const hero = { attack: 1, health: 5, gems: 0, damage: 0, name: 'Hero' };
+  const monster = { attack: 1, health: 5, damage: 0, name: 'Monster' };
 
-
-  function saveCharacterData() {
-    try {
-      if (window.preloadedData?.characters?.heroes?.shellfin) {
-        window.preloadedData.characters.heroes.shellfin.level = hero.level;
-        window.preloadedData.characters.heroes.shellfin.experience = hero.experience;
-        localStorage.setItem('characters', JSON.stringify(window.preloadedData.characters));
-      }
-    } catch (err) {
-      console.error('Failed to save character data', err);
-    }
-  }
-
-  function applyDamage(attacker, defender) {
-    defender.damage = Number(defender.damage) + Number(attacker.attack);
-  }
-
-  function shuffle(array) {
-    for (let i = array.length - 1; i > 0; i--) {
+  function shuffle(arr) {
+    for (let i = arr.length - 1; i > 0; i--) {
       const j = Math.floor(Math.random() * (i + 1));
-      [array[i], array[j]] = [array[j], array[i]];
+      [arr[i], arr[j]] = [arr[j], arr[i]];
     }
-    return array;
+    return arr;
   }
 
   function loadData() {
     const data = window.preloadedData;
-    if (!data || !data.characters || !data.missions) return;
-
-    hero = data.characters.heroes.shellfin;
-    foe = data.characters.monsters.octomurk;
-
-    const walkthrough = data.missions.Walkthrough;
-    questions = shuffle(walkthrough.questions || []);
-    totalQuestions = questions.length;
-    missionExperience = walkthrough.experience || 0;
-
-    foe.health = totalQuestions;
-    foe.damage = Number(foe.damage) || 0;
-
-    shellfinName.textContent = hero.name;
-    monsterName.textContent = foe.name;
-
-    const heroHpPercent = ((hero.health - hero.damage) / hero.health) * 100;
-    const monsterHpPercent = ((foe.health - foe.damage) / foe.health) * 100;
-    shellfinHpFill.style.width = heroHpPercent + '%';
-    monsterHpFill.style.width = monsterHpPercent + '%';
-
-    const starts = Object.values(hero.levels).map((l) => Number(l.start));
-    maxLevelStart = Math.max(...starts);
-
-    // Show the battle view once data is ready
-    game.style.display = 'none';
-    battleDiv.style.display = 'block';
+    if (data && data.characters && data.missions) {
+      const heroData = data.characters.heroes.shellfin;
+      const monsterData = data.characters.monsters.octomurk;
+      hero.attack = Number(heroData.attack) || hero.attack;
+      hero.health = Number(heroData.health) || hero.health;
+      hero.name = heroData.name || hero.name;
+      monster.attack = Number(monsterData.attack) || monster.attack;
+      monster.health = Number(monsterData.health) || monster.health;
+      monster.name = monsterData.name || monster.name;
+      questions = shuffle(data.missions.Walkthrough.questions || []);
+    }
+    attackVal.textContent = hero.attack;
+    healthVal.textContent = hero.health;
+    gemVal.textContent = hero.gems;
+    heroNameEl.textContent = hero.name;
+    monsterNameEl.textContent = monster.name;
+    updateHealthBars();
   }
 
-  document.addEventListener('assets-loaded', loadData);
-  loadData();
-
-  function updateLevelProgress(reset = false) {
-    if (!hero || !hero.levels) return;
-    const currentLevelData = hero.levels[hero.level];
-    const nextLevelData = hero.levels[hero.level + 1];
-    const currentStart = Number(currentLevelData.start);
-    const nextStart = nextLevelData ? Number(nextLevelData.start) : maxLevelStart;
-    const progressPercent = ((hero.experience - currentStart) / (nextStart - currentStart || 1)) * 100;
-
-    if (reset) {
-      xpFill.style.transition = 'none';
-      xpFill.style.width = '0%';
-      void xpFill.offsetWidth; // reflow
-      xpFill.style.transition = 'width 0.6s linear';
-    }
-    xpFill.style.width = Math.min(Math.max(progressPercent, 0), 100) + '%';
+  function updateHealthBars() {
+    const heroPercent = ((hero.health - hero.damage) / hero.health) * 100;
+    const monsterPercent = ((monster.health - monster.damage) / monster.health) * 100;
+    heroHpFill.style.width = heroPercent + '%';
+    monsterHpFill.style.width = monsterPercent + '%';
   }
 
   function showQuestion() {
-    overlay.classList.add('show');
+    const q = questions[currentQuestion];
+    if (!q) return;
+    headingEl.textContent = 'Question';
+    questionText.textContent = q.question || '';
+    choicesEl.innerHTML = '';
+    (q.choices || []).forEach((choice) => {
+      const div = document.createElement('div');
+      div.classList.add('choice');
+      div.dataset.correct = !!choice.correct;
+      if (choice.image) {
+        const img = document.createElement('img');
+        img.src = `../images/questions/${choice.image}`;
+        img.alt = choice.name || '';
+        div.appendChild(img);
+      }
+      const p = document.createElement('p');
+      p.textContent = choice.name || '';
+      div.appendChild(p);
+      choicesEl.appendChild(div);
+    });
+    questionBox.classList.add('show');
+  }
 
-    const setupQuestion = () => {
-      const q = questions[currentQuestion];
-      if (!q) return;
-
-      if (currentQuestion === 0 && answeredQuestions === 0) startTime = Date.now();
-
-      const num = currentQuestion + 1;
-      questionHeading.textContent = `Question ${num} of ${totalQuestions}`;
-      questionText.textContent = q.question || '';
-      choices.innerHTML = '';
-      questionButton.disabled = true;
-
-      (q.choices || []).forEach((choice) => {
-        const div = document.createElement('div');
-        div.classList.add('choice');
-        div.dataset.correct = !!choice.correct;
-        if (choice.image) {
-          const img = document.createElement('img');
-          img.src = `../images/questions/${choice.image}`;
-          img.alt = choice.name || '';
-          div.appendChild(img);
-        }
-        const p = document.createElement('p');
-        p.textContent = choice.name || '';
-        div.appendChild(p);
-        choices.appendChild(div);
-      });
-
-      const percent = (currentQuestion / totalQuestions) * 100;
-      progressFill.style.width = percent + '%';
-      questionBox.classList.add('show');
-    };
-
-    if (message.classList.contains('show')) {
-      const handleSlide = (e) => {
-        if (e.propertyName === 'transform') {
-          message.removeEventListener('transitionend', handleSlide);
-          setupQuestion();
-        }
-      };
-      message.addEventListener('transitionend', handleSlide, { once: true });
-      message.classList.remove('show');
+  function updateStreak() {
+    const percent = Math.min(streak / STREAK_GOAL, 1) * 100;
+    progressFill.style.width = percent + '%';
+    if (streak > 0) {
+      streakLabel.textContent = `${streak} in a Row`;
+      streakLabel.classList.remove('show');
+      void streakLabel.offsetWidth;
+      streakLabel.classList.add('show');
     } else {
-      setupQuestion();
+      streakLabel.textContent = '';
     }
   }
 
-  function showBattleIntro() {
-    genericImg.style.display = 'none';
-    genericP.textContent =
-      "It’s battle time! Answer questions to power your attacks. Miss one, and your enemy fights back! Let's get learning!";
-    button.textContent = 'Battle';
-    overlay.classList.add('show');
-    message.classList.add('show');
+  function showIncrease(el) {
+    el.textContent = '+1';
+    el.classList.remove('show');
+    void el.offsetWidth;
+    el.classList.add('show');
+  }
 
-    button.onclick = () => {
-      genericImg.style.display = '';
-      button.textContent = 'Continue';
-      message.classList.remove('show');
-      overlay.classList.remove('show');
-      showQuestion();
+  function heroAttack() {
+    heroImg.classList.add('attack');
+    const handler = (e) => {
+      if (e.animationName !== 'hero-attack') return;
+      heroImg.classList.remove('attack');
+      heroImg.removeEventListener('animationend', handler);
+      monster.damage += hero.attack;
+      updateHealthBars();
+      if (monster.damage >= monster.health) {
+        endBattle(true);
+      } else {
+        currentQuestion++;
+        showQuestion();
+      }
     };
+    heroImg.addEventListener('animationend', handler);
+  }
+
+  function monsterAttack() {
+    monsterImg.classList.add('attack');
+    const handler = (e) => {
+      if (e.animationName !== 'monster-attack') return;
+      monsterImg.classList.remove('attack');
+      monsterImg.removeEventListener('animationend', handler);
+      hero.damage += monster.attack;
+      updateHealthBars();
+      if (hero.damage >= hero.health) {
+        endBattle(false);
+      } else {
+        currentQuestion++;
+        showQuestion();
+      }
+    };
+    monsterImg.addEventListener('animationend', handler);
   }
 
   document.addEventListener('answer-submitted', (e) => {
-    overlay.classList.remove('show');
-    answeredQuestions++;
-    if (e.detail.correct) {
-      correctAnswers++;
-      if (correctAnswers === totalQuestions) {
-        endTime = Date.now();
+    const correct = e.detail.correct;
+    questionBox.classList.remove('show');
+    if (correct) {
+      streak++;
+      updateStreak();
+      const stat = ['attack', 'health', 'gem'][Math.floor(Math.random() * 3)];
+      if (stat === 'attack') {
+        hero.attack++;
+        attackVal.textContent = hero.attack;
+        showIncrease(attackInc);
+      } else if (stat === 'health') {
+        hero.health++;
+        healthVal.textContent = hero.health;
+        showIncrease(healthInc);
+        updateHealthBars();
+      } else {
+        hero.gems++;
+        gemVal.textContent = hero.gems;
+        showIncrease(gemInc);
       }
-      heroAttack(true, () => nextTurn(true));
+      setTimeout(heroAttack, 3000);
     } else {
-      const wrongQuestion = questions.splice(currentQuestion, 1)[0];
-      const insertIndex =
-        currentQuestion +
-        Math.floor(Math.random() * (questions.length - currentQuestion + 1));
-      questions.splice(insertIndex, 0, wrongQuestion);
-      monsterAttack(() => nextTurn(false), 300);
+      streak = 0;
+      updateStreak();
+      setTimeout(monsterAttack, 3000);
     }
   });
 
-  function endBattle(result) {
-    if (result === 'win') {
-      setTimeout(() => {
-        battleDiv.style.display = 'none';
-        game.style.display = 'block';
-
-        introShellfin.style.display = 'none';
-        introMonster.src = '../images/battle/monster_battle_dead.png';
-        introMonster.style.display = 'block';
-
-        introMonster.classList.remove('pop', 'pop-in');
-        introMonster.style.animation = 'none';
-        introMonster.style.transform = 'translateX(-50%) scale(0)';
-        void introMonster.offsetWidth;
-        introMonster.style.animation = '';
-        introMonster.classList.add('pop-in');
-
-        setTimeout(() => {
-          heroNameDisplay.textContent = 'Mission Complete';
-          const accuracy = Math.round((correctAnswers / answeredQuestions) * 100);
-          attackDisplay.textContent = `${accuracy}%`;
-          const speed = Math.max(0, Math.floor((endTime - startTime) / 1000));
-          healthDisplay.textContent = `${speed}s`;
-
-          xpFill.style.transition = 'none';
-          updateLevelProgress();
-          void xpFill.offsetWidth;
-          xpFill.style.transition = 'width 0.6s linear';
-
-          message.classList.add('win');
-          overlay.classList.add('show');
-          message.classList.add('show');
-
-          // Avoid duplicate handlers
-          claimButton.onclick = null;
-
-          setTimeout(() => {
-            // Snapshot BEFORE XP changes
-            const oldLevel = hero.level;
-
-            const currentStart = Number(hero.levels[hero.level].start);
-            const nextStart = Number(hero.levels[hero.level + 1]?.start || maxLevelStart);
-
-            // Award XP
-            hero.experience += missionExperience;
-
-            // Animate the XP bar to the new fill
-            const fillPercent = Math.min(
-              ((hero.experience - currentStart) / (nextStart - currentStart || 1)) * 100,
-              100
-            );
-            xpFill.addEventListener('transitionend', function handleXp(e) {
-              if (e.propertyName !== 'width') return;
-              xpFill.removeEventListener('transitionend', handleXp);
-
-              // Level-up check (single-step; expand if you want multi-level jumps)
-              if (hero.experience >= nextStart && hero.levels[hero.level + 1]) {
-                hero.level += 1;
-                
-                saveCharacterData();
-
-                levelUpBadge.classList.remove('show');
-                void levelUpBadge.offsetWidth;
-                levelUpBadge.classList.add('show');
-              }
-            }, { once: true });
-
-            xpFill.style.width = fillPercent + '%';
-
-            claimButton.onclick = () => {
-              message.classList.remove('show');
-              overlay.classList.remove('show');
-
-              // After the slide-out finishes, reset the progress bar (nice polish)
-              message.addEventListener('transitionend', () => updateLevelProgress(true), { once: true });
-
-              // Pop the monster away first
-              introMonster.classList.remove('pop', 'pop-in');
-              introMonster.classList.add('pop');
-              introMonster.addEventListener('animationend', function handleMonsterPop(e) {
-                if (e.animationName !== 'bubble-pop') return;
-                introMonster.removeEventListener('animationend', handleMonsterPop);
-                introMonster.style.display = 'none';
-
-                // Determine NEW state AFTER any level-up happened
-                const newLevel = hero.level;
-                const hadLevelUp = newLevel > oldLevel;
-
-                // 1) Show OLD sprite (always)
-                introShellfin.src = `../images/characters/${hero.levels[oldLevel]?.image}`;
-                introShellfin.style.display = 'block';
-                introShellfin.classList.remove('center', 'pop', 'pop-in');
-                introShellfin.style.animation = 'none';
-                introShellfin.style.transform = 'translateX(100vw)';
-                void introShellfin.offsetWidth;
-                setTimeout(() => {
-                  introShellfin.style.animation = 'swim 2s forwards';
-                }, 400);
-
-                // When old sprite swim finishes, show message
-                introShellfin.addEventListener('animationend', function handleSwim(ev) {
-                  if (ev.animationName !== 'swim') return;
-                  introShellfin.removeEventListener('animationend', handleSwim);
-
-                  genericImg.src = '../images/message/shellfin_message.png';
-                  genericP.textContent = hadLevelUp
-                    ? "Now that I leveled up, I’m ready to evolve and become even more powerful."
-                    : "Nice win! Let’s keep training to grow stronger.";
-                  button.textContent = 'Continue';
-                  overlay.classList.add('show');
-                  message.classList.remove('win');
-                  message.classList.add('show');
-
-                  // On continue, wait briefly then pop out OLD sprite, then pop-in NEW (or same if no level-up)
-                  button.onclick = () => {
-                    message.classList.remove('show');
-                    overlay.classList.remove('show');
-
-                    introShellfin.classList.remove('pop', 'pop-in');
-                    introShellfin.style.animation = 'none';
-                    introShellfin.style.transform = 'translateX(-50%)';
-                    void introShellfin.offsetWidth;
-                    introShellfin.style.animation = '';
-
-                    setTimeout(() => {
-                      introShellfin.classList.add('pop');
-
-                      introShellfin.addEventListener('animationend', function handlePop(e2) {
-                        if (e2.animationName !== 'bubble-pop') return;
-                        introShellfin.removeEventListener('animationend', handlePop);
-
-                        const showLevel = hadLevelUp ? newLevel : oldLevel;
-                        introShellfin.src = `../images/characters/${hero.levels[showLevel]?.image}`;
-
-                        introShellfin.classList.remove('pop');
-                        introShellfin.classList.add('pop-in');
-
-                        introShellfin.addEventListener('animationend', function handlePopIn(ev2) {
-                          if (ev2.animationName !== 'bubble-pop-in') return;
-                          introShellfin.classList.remove('pop-in');
-                          introShellfin.removeEventListener('animationend', handlePopIn);
-
-                          setTimeout(() => {
-                            genericImg.src = '../images/message/shellfin_message.png';
-                        
-                            genericP.textContent =
-                              'Barnacle armor – awesome! Take on more missions to learn about the ocean and evolve me even further!';
-                            button.textContent = 'Continue';
-                            overlay.classList.add('show');
-                            message.classList.add('show');
-                          }, 400);
-                        }, { once: true });
-                      }, { once: true });
-                    }, 400);
-                  };
-                }, { once: true });
-              }, { once: true });
-            };
-          }, 1600);
-        }, 3200);
-      }, 300);
-      return;
-    }
-
-    // Lose
-    message.querySelector('.generic-content p').textContent = 'lose';
-    overlay.classList.add('show');
-    message.classList.add('show');
-    button.onclick = null;
+  function endBattle(win) {
+    levelText.textContent = win ? 'you win' : 'you lose';
+    levelMessage.classList.add('show');
   }
 
-  function heroAttack(correct, after) {
-    setTimeout(() => {
-      shellfin.classList.add('attack');
-      const handleHero = (e) => {
-        if (e.animationName !== 'hero-attack') return;
-        shellfin.classList.remove('attack');
-        shellfin.removeEventListener('animationend', handleHero);
+  levelButton.addEventListener('click', () => {
+    window.location.reload();
+  });
 
-        applyDamage(hero, foe);
-        const percent = ((foe.health - foe.damage) / foe.health) * 100;
-        monsterHpFill.style.width = percent + '%';
-
-        const afterBar = (ev) => {
-          if (ev.propertyName !== 'width') return;
-          monsterHpFill.removeEventListener('transitionend', afterBar);
-
-          if (foe.damage >= foe.health) {
-            endBattle('win');
-            return;
-          }
-
-          setTimeout(() => {
-            if (after) after();
-            else showFeedback(correct);
-          }, 1200);
-        };
-        monsterHpFill.addEventListener('transitionend', afterBar, { once: true });
-      };
-      shellfin.addEventListener('animationend', handleHero, { once: true });
-    }, ATTACK_DELAY_MS);
-  }
-
-  function monsterAttack(after, postDelay = 1200) {
-    setTimeout(() => {
-      monster.classList.add('attack');
-      const handleMonster = (e) => {
-        if (e.animationName !== 'monster-attack') return;
-        monster.classList.remove('attack');
-        monster.removeEventListener('animationend', handleMonster);
-
-        applyDamage(foe, hero);
-        const percent = ((hero.health - hero.damage) / hero.health) * 100;
-        shellfinHpFill.style.width = percent + '%';
-
-        const afterBar = (ev) => {
-          if (ev.propertyName !== 'width') return;
-          shellfinHpFill.removeEventListener('transitionend', afterBar);
-
-          if (hero.damage >= hero.health) {
-            endBattle('lose');
-            return;
-          }
-
-          setTimeout(() => {
-            if (after) after();
-            else showFeedback(false);
-          }, postDelay);
-        };
-        shellfinHpFill.addEventListener('transitionend', afterBar, { once: true });
-      };
-      monster.addEventListener('animationend', handleMonster, { once: true });
-    }, ATTACK_DELAY_MS);
-  }
-
-  function nextTurn(increment = true) {
-    if (increment) currentQuestion++;
-    if (currentQuestion < questions.length) {
-      showQuestion();
-    }
-  }
-
-  let done = 0;
-  function handleEnd(e) {
-    e.target.classList.remove('enter');
-    e.target.removeEventListener('animationend', handleEnd);
-    done++;
-    if (done === 2) {
-      let statsDone = 0;
-      const statsHandler = (ev) => {
-        if (ev.propertyName !== 'transform') return;
-        statsDone++;
-        if (statsDone === 2) {
-          shellfinStats.removeEventListener('transitionend', statsHandler);
-          monsterStats.removeEventListener('transitionend', statsHandler);
-          setTimeout(showBattleIntro, 3000);
-        }
-      };
-      shellfinStats.addEventListener('transitionend', statsHandler);
-      monsterStats.addEventListener('transitionend', statsHandler);
-      shellfinStats.classList.add('show');
-      monsterStats.classList.add('show');
-    }
-  }
-
-  monster.addEventListener('animationend', handleEnd);
-  shellfin.addEventListener('animationend', handleEnd);
-
+  loadData();
+  showQuestion();
 });

--- a/js/question.js
+++ b/js/question.js
@@ -44,7 +44,7 @@ document.addEventListener('DOMContentLoaded', () => {
         if (e.propertyName === 'transform') {
           questionBox.removeEventListener('transitionend', handleSlide);
           button.classList.remove('result', 'correct', 'incorrect');
-          button.textContent = 'Answer';
+          button.textContent = 'Submit';
           Array.from(choicesContainer.children).forEach((c) =>
             c.classList.remove('selected', 'correct-choice', 'wrong-choice')
           );


### PR DESCRIPTION
## Summary
- remove overlay messages and implement question-result battle loop
- add streak progress bar with attack, health, gem stat counters
- show end-of-battle message for win or lose
- remove placeholder stat icons to allow asset export

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1c26cbb5083299d798cce140b33c2