### PR TITLE
Add config JSON for battle variables

### DIFF
--- a/data/config.json
+++ b/data/config.json
@@ -1,0 +1,16 @@
+{
+  "streakGoal": 10,
+  "hero": {
+    "attack": 1,
+    "health": 5,
+    "gems": 0,
+    "damage": 0,
+    "name": "Hero"
+  },
+  "monster": {
+    "attack": 1,
+    "health": 5,
+    "damage": 0,
+    "name": "Monster"
+  }
+}

--- a/js/battle.js
+++ b/js/battle.js
@@ -23,7 +23,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const levelText = levelMessage.querySelector('p');
   const levelButton = levelMessage.querySelector('button');
 
-  const STREAK_GOAL = 10;
+  let STREAK_GOAL = 10;
   let questions = [];
   let currentQuestion = 0;
   let streak = 0;
@@ -41,6 +41,21 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function loadData() {
     const data = window.preloadedData;
+    const config = data.config || {};
+    STREAK_GOAL = Number(config.streakGoal) || STREAK_GOAL;
+    if (config.hero) {
+      hero.attack = Number(config.hero.attack) || hero.attack;
+      hero.health = Number(config.hero.health) || hero.health;
+      hero.gems = Number(config.hero.gems) || hero.gems;
+      hero.damage = Number(config.hero.damage) || hero.damage;
+      hero.name = config.hero.name || hero.name;
+    }
+    if (config.monster) {
+      monster.attack = Number(config.monster.attack) || monster.attack;
+      monster.health = Number(config.monster.health) || monster.health;
+      monster.damage = Number(config.monster.damage) || monster.damage;
+      monster.name = config.monster.name || monster.name;
+    }
     if (data && data.characters && data.missions) {
       const heroData = data.characters.heroes.shellfin;
       const monsterData = data.characters.monsters.octomurk;

--- a/js/loader.js
+++ b/js/loader.js
@@ -21,11 +21,13 @@ document.addEventListener('DOMContentLoaded', () => {
 
     Promise.all([
       charactersPromise,
-      fetch('../data/missions.json').then((res) => res.json())
+      fetch('../data/missions.json').then((res) => res.json()),
+      fetch('../data/config.json').then((res) => res.json())
     ])
-      .then(async ([characters, missions]) => {
+      .then(async ([characters, missions, config]) => {
         window.preloadedData.characters = characters;
         window.preloadedData.missions = missions;
+        window.preloadedData.config = config;
 
         if (battleId && window.supabaseClient) {
           try {


### PR DESCRIPTION
## Summary
- centralize game variables in new `data/config.json`
- load config during startup and expose to scripts
- use config to set streak goal and default stats in battle logic

## Testing
- `node --check js/loader.js`
- `node --check js/battle.js`
- `node -e "const fs=require('fs'); JSON.parse(fs.readFileSync('data/config.json','utf8')); console.log('config json valid');"`

------
https://chatgpt.com/codex/tasks/task_e_68c1c7f7f7d48329a528dc95e451c779