### PR TITLE
Remove shellfin entry animation and fix battle data load

### DIFF
--- a/css/battle.css
+++ b/css/battle.css
@@ -11,34 +11,14 @@
   max-width: 80vw;
 }
 
-/* Monster slides in from the right */
 #battle-monster {
   top: 10%;
   left: 55%;
 }
 
-#battle-monster.enter {
-  animation: monster-slide 1s ease-out forwards;
-}
-
-@keyframes monster-slide {
-  from { transform: translateX(100%); }
-  to   { transform: translateX(0); }
-}
-
-/* Shellfin slides in from the left */
 #battle-shellfin {
   bottom: 10%;
   right: 55%;
-}
-
-#battle-shellfin.enter {
-  animation: shellfin-slide 1s ease-out forwards;
-}
-
-@keyframes shellfin-slide {
-  from { transform: translateX(-100%); }
-  to   { transform: translateX(0); }
 }
 
 .stat-box {

--- a/html/battle.html
+++ b/html/battle.html
@@ -17,8 +17,8 @@
      <img id="monster" src="../images/battle/monster_battle.png" alt="monster" />
   </div>
   <div id="battle" style="display: none;">
-    <img id="battle-monster" class="enter" src="../images/battle/monster_battle.png" alt="Monster" />
-    <img id="battle-shellfin" class="enter" src="../images/battle/shellfin_battle.png" alt="Shellfin" />
+    <img id="battle-monster" src="../images/battle/monster_battle.png" alt="Monster" />
+    <img id="battle-shellfin" src="../images/battle/shellfin_battle.png" alt="Shellfin" />
     <div id="monster-stats" class="stat-box">
       <div class="name"></div>
       <div class="hp-bar"><div class="hp-fill"></div></div>

--- a/js/loader.js
+++ b/js/loader.js
@@ -21,10 +21,29 @@ document.addEventListener('DOMContentLoaded', () => {
 
     Promise.all([
       charactersPromise,
-      fetch('../data/missions.json').then((res) => res.json()),
+      fetch('../data/questions.json').then((res) => res.json()),
       fetch('../data/config.json').then((res) => res.json())
     ])
-      .then(async ([characters, missions, config]) => {
+      .then(async ([characters, questionsData, config]) => {
+        const missions = { Walkthrough: { questions: [], total: 0 } };
+        if (questionsData?.questions) {
+          missions.Walkthrough.questions = questionsData.questions.map(
+            (q, idx) => ({
+              name: `Question ${idx + 1}`,
+              number: idx + 1,
+              question: q.question,
+              choices: (q.options || []).map((opt) => ({
+                name: opt,
+                correct: opt === q.answer,
+              })),
+            })
+          );
+          missions.Walkthrough.total = missions.Walkthrough.questions.length;
+        }
+        if (characters?.monsters?.octomurk) {
+          characters.monsters.octomurk.health = missions.Walkthrough.questions.length;
+          characters.monsters.octomurk.damage = 0;
+        }
         window.preloadedData.characters = characters;
         window.preloadedData.missions = missions;
         window.preloadedData.config = config;


### PR DESCRIPTION
## Summary
- Remove initial entry animations for battle characters so combat begins immediately
- Load questions from `data/questions.json` and map them into battle missions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1c9f3686c83299fa27691cd933f9f