### PR TITLE
Start battle with immediate slide-in

### DIFF
--- a/css/battle.css
+++ b/css/battle.css
@@ -11,6 +11,14 @@
   max-width: 80vw;
 }
 
+#battle-monster.slide-in {
+  animation: monster-enter 0.5s ease-out forwards;
+}
+
+#battle-shellfin.slide-in {
+  animation: hero-enter 0.5s ease-out forwards;
+}
+
 #battle-monster {
   top: 10%;
   left: 55%;
@@ -79,6 +87,24 @@
 
 #battle-monster.attack {
   animation: monster-attack 0.5s ease-in-out;
+}
+
+@keyframes hero-enter {
+  from {
+    transform: translateX(150%);
+  }
+  to {
+    transform: translateX(0);
+  }
+}
+
+@keyframes monster-enter {
+  from {
+    transform: translateX(-150%);
+  }
+  to {
+    transform: translateX(0);
+  }
 }
 
 @keyframes hero-attack {

--- a/html/battle.html
+++ b/html/battle.html
@@ -12,11 +12,7 @@
     <link rel="stylesheet" href="../css/battle.css" />
   </head>
   <body>
-  <div id="game">
-     <img id="shellfin" src="../images/characters/shellfin_level_1.png" alt="Shellfin" />
-     <img id="monster" src="../images/battle/monster_battle.png" alt="monster" />
-  </div>
-  <div id="battle" style="display: none;">
+  <div id="battle">
     <img id="battle-monster" src="../images/battle/monster_battle.png" alt="Monster" />
     <img id="battle-shellfin" src="../images/battle/shellfin_battle.png" alt="Shellfin" />
     <div id="monster-stats" class="stat-box">

--- a/js/battle.js
+++ b/js/battle.js
@@ -5,6 +5,8 @@ document.addEventListener('DOMContentLoaded', () => {
   const heroHpFill = document.querySelector('#shellfin-stats .hp-fill');
   const monsterNameEl = document.querySelector('#monster-stats .name');
   const heroNameEl = document.querySelector('#shellfin-stats .name');
+  const monsterStats = document.getElementById('monster-stats');
+  const heroStats = document.getElementById('shellfin-stats');
 
   const questionBox = document.getElementById('question');
   const questionText = questionBox.querySelector('p');
@@ -30,6 +32,22 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const hero = { attack: 1, health: 5, gems: 0, damage: 0, name: 'Hero' };
   const monster = { attack: 1, health: 5, damage: 0, name: 'Monster' };
+
+  heroImg.classList.add('slide-in');
+  monsterImg.classList.add('slide-in');
+  heroStats.classList.add('show');
+  monsterStats.classList.add('show');
+
+  heroImg.addEventListener(
+    'animationend',
+    () => heroImg.classList.remove('slide-in'),
+    { once: true }
+  );
+  monsterImg.addEventListener(
+    'animationend',
+    () => monsterImg.classList.remove('slide-in'),
+    { once: true }
+  );
 
   function shuffle(arr) {
     for (let i = arr.length - 1; i > 0; i--) {


### PR DESCRIPTION
## Summary
- Remove intro splash so battle starts immediately
- Add slide-in animation for battle sprites and show stats on load

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68c1cdb7cec08329acd0869d481da003