### PR TITLE
Add index redirect, level layout update, and battle data

### DIFF
--- a/css/level.css
+++ b/css/level.css
@@ -37,11 +37,11 @@ body {
   overflow: hidden;
 }
 
-.level-message .progress-fill {
-  height: 100%;
-  width: 0%;
-  background: #006AFF;
-  border-radius: 4px;
+.level-message .level-info {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
 }
 
 .level-message .math-type {

--- a/data/levels.json
+++ b/data/levels.json
@@ -1,0 +1,10 @@
+{
+  "levels": [
+    {
+      "id": 1,
+      "math": "Addition",
+      "enemySprite": "battle/monster_battle.png",
+      "progress": 0
+    }
+  ]
+}

--- a/data/variables.json
+++ b/data/variables.json
@@ -1,0 +1,20 @@
+{
+  "config": {
+    "streakGoal": 10,
+    "hero": { "attack": 1, "health": 5, "gems": 0, "damage": 0, "name": "Hero" },
+    "monster": { "attack": 1, "health": 5, "damage": 0, "name": "Monster" }
+  },
+  "characters": {
+    "heroes": {
+      "shellfin": { "name": "Shellfin", "attack": 1, "health": 5 }
+    },
+    "monsters": {
+      "octomurk": { "name": "Octomurk", "attack": 1, "health": 5 }
+    }
+  },
+  "missions": {
+    "Walkthrough": {
+      "questions": []
+    }
+  }
+}

--- a/html/level.html
+++ b/html/level.html
@@ -8,9 +8,11 @@
 </head>
 <body>
   <div class="level-message">
-    <p class="level-title level-number">Level 1</p>
     <div class="progress-bar"><div class="progress-fill"></div></div>
-    <p class="math-type">Addition</p>
+    <div class="level-info">
+      <p class="level-title level-number">Level 1</p>
+      <p class="math-type">Addition</p>
+    </div>
     <img class="enemy-image" src="../images/battle/monster_battle.png" alt="Enemy" />
     <button class="btn-primary battle-btn">Battle</button>
   </div>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Redirecting...</title>
+  <meta http-equiv="refresh" content="0; url=html/level.html" />
+  <script>
+    window.location.href = 'html/level.html';
+  </script>
+</head>
+<body>
+  <p>Loading level...</p>
+</body>
+</html>

--- a/js/battle.js
+++ b/js/battle.js
@@ -219,5 +219,5 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   loadData();
-  showQuestion();
+  setTimeout(showQuestion, 3000);
 });

--- a/js/loader.js
+++ b/js/loader.js
@@ -1,0 +1,17 @@
+(async function() {
+  try {
+    const [varsRes, questionsRes] = await Promise.all([
+      fetch('../data/variables.json'),
+      fetch('../data/questions.json')
+    ]);
+    const varsData = await varsRes.json();
+    const questionsData = await questionsRes.json();
+    if (!varsData.missions) varsData.missions = {};
+    if (!varsData.missions.Walkthrough) varsData.missions.Walkthrough = {};
+    varsData.missions.Walkthrough.questions = questionsData.questions || [];
+    window.preloadedData = varsData;
+  } catch (e) {
+    console.error('Failed to load data', e);
+    window.preloadedData = {};
+  }
+})();


### PR DESCRIPTION
## Summary
- Add root index.html to redirect directly to level screen
- Move progress bar to top of level card and group level & math info with 8px gap
- Provide battle configuration JSON and loader plus delay first question by 3 seconds

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1d1b8355c832997e7a738b7cb28b9