### PR TITLE
Handle missing hero or monster data

### DIFF
--- a/js/battle.js
+++ b/js/battle.js
@@ -75,15 +75,19 @@ document.addEventListener('DOMContentLoaded', () => {
       monster.name = config.monster.name || monster.name;
     }
     if (data && data.characters && data.missions) {
-      const heroData = data.characters.heroes.shellfin;
-      const monsterData = data.characters.monsters.octomurk;
-      hero.attack = Number(heroData.attack) || hero.attack;
-      hero.health = Number(heroData.health) || hero.health;
-      hero.name = heroData.name || hero.name;
-      monster.attack = Number(monsterData.attack) || monster.attack;
-      monster.health = Number(monsterData.health) || monster.health;
-      monster.name = monsterData.name || monster.name;
-      questions = shuffle(data.missions.Walkthrough.questions || []);
+      const heroData = data.characters.heroes?.shellfin;
+      const monsterData = data.characters.monsters?.octomurk;
+      if (heroData) {
+        hero.attack = Number(heroData.attack) || hero.attack;
+        hero.health = Number(heroData.health) || hero.health;
+        hero.name = heroData.name || hero.name;
+      }
+      if (monsterData) {
+        monster.attack = Number(monsterData.attack) || monster.attack;
+        monster.health = Number(monsterData.health) || monster.health;
+        monster.name = monsterData.name || monster.name;
+      }
+      questions = shuffle(data.missions.Walkthrough?.questions || []);
     }
     attackVal.textContent = hero.attack;
     healthVal.textContent = hero.health;


### PR DESCRIPTION
## Summary
- guard against absent hero or monster character data so stats always render

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1d591c5b0832998573b7046bbaed1