### PR TITLE
Align battle question progress and status

### DIFF
--- a/css/question.css
+++ b/css/question.css
@@ -52,13 +52,22 @@
   color: #272B34;
 }
 
+#question .top-bar {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  margin-bottom: 16px;
+}
+
 #question .progress-bar {
   width: 100%;
   height: 16px;
   background: #F4F6FA;
   border-radius: 4px;
   overflow: hidden;
-  margin-bottom: 8px;
+  margin-bottom: 0;
+  margin-right: 8px;
+  flex: 1;
 }
 
 #question .progress-fill {
@@ -94,6 +103,12 @@
   margin: 8px 0 16px;
 }
 
+#question .top-bar .status {
+  width: auto;
+  margin: 0;
+  gap: 16px;
+}
+
 #question .status .stat {
   position: relative;
   display: flex;
@@ -104,8 +119,14 @@
 }
 
 #question .status .stat img {
-  width: 24px;
-  height: 24px;
+  width: 20px;
+  height: 20px;
+}
+
+#question .status .stat .value {
+  font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
+  font-size: 20px;
+  color: #006AFF;
 }
 
 #question .status .stat .increase {

--- a/html/battle.html
+++ b/html/battle.html
@@ -25,13 +25,15 @@
     </div>
   </div>
     <div id="question">
-      <div class="progress-bar"><div class="progress-fill"></div></div>
-      <div class="streak-label"></div>
-      <div class="status">
-        <div class="stat attack"><img src="../images/questions/sword.png" alt="Attack" /><span class="value">0</span><div class="increase"></div></div>
-        <div class="stat health"><img src="../images/questions/shield.png" alt="Health" /><span class="value">0</span><div class="increase"></div></div>
-        <div class="stat gem"><img src="../images/questions/gem.png" alt="Gem" /><span class="value">0</span><div class="increase"></div></div>
+      <div class="top-bar">
+        <div class="progress-bar"><div class="progress-fill"></div></div>
+        <div class="status">
+          <div class="stat attack"><img src="../images/questions/sword.png" alt="Attack" /><span class="value">0</span><div class="increase"></div></div>
+          <div class="stat health"><img src="../images/questions/shield.png" alt="Health" /><span class="value">0</span><div class="increase"></div></div>
+          <div class="stat gem"><img src="../images/questions/gem.png" alt="Gem" /><span class="value">0</span><div class="increase"></div></div>
+        </div>
       </div>
+      <div class="streak-label"></div>
       <h1>Question</h1>
       <p></p>
       <div class="choices"></div>


### PR DESCRIPTION
## Summary
- Align battle question progress bar with status icons on a single row
- Standardize status icons to 20x20 and apply consistent value text styling

## Testing
- `npm test` *(fails: ENOENT no such file package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1d87dcd2883298f3732f2a6f48e92