### PR TITLE
Delay reward animation sequence for correct answers

### DIFF
--- a/css/question.css
+++ b/css/question.css
@@ -94,7 +94,7 @@
   font-size: 16px;
   color: #006AFF;
   margin-top: 4px;
-  align-self: flex-end;
+  align-self: flex-start;
   opacity: 0;
   transform: scale(0.8);
 }

--- a/js/battle.js
+++ b/js/battle.js
@@ -138,7 +138,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const percent = Math.min(streak / STREAK_GOAL, 1) * 100;
     progressFill.style.width = percent + '%';
     if (streak > 0) {
-      streakLabel.textContent = `${streak} in a Row`;
+      streakLabel.textContent = `${streak} in a row`;
       streakLabel.classList.remove('show');
       void streakLabel.offsetWidth;
       streakLabel.classList.add('show');
@@ -156,25 +156,23 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   function heroAttack() {
-    setTimeout(() => {
-      heroImg.classList.add('attack');
-      const handler = (e) => {
-        if (e.animationName !== 'hero-attack') return;
-        heroImg.classList.remove('attack');
-        heroImg.removeEventListener('animationend', handler);
-        setTimeout(() => {
-          monster.damage += hero.attack;
-          updateHealthBars();
-          if (monster.damage >= monster.health) {
-            endBattle(true);
-          } else {
-            currentQuestion++;
-            showQuestion();
-          }
-        }, 1000);
-      };
-      heroImg.addEventListener('animationend', handler);
-    }, 1000);
+    heroImg.classList.add('attack');
+    const handler = (e) => {
+      if (e.animationName !== 'hero-attack') return;
+      heroImg.classList.remove('attack');
+      heroImg.removeEventListener('animationend', handler);
+      setTimeout(() => {
+        monster.damage += hero.attack;
+        updateHealthBars();
+        if (monster.damage >= monster.health) {
+          endBattle(true);
+        } else {
+          currentQuestion++;
+          showQuestion();
+        }
+      }, 1000);
+    };
+    heroImg.addEventListener('animationend', handler);
   }
 
   function monsterAttack() {
@@ -223,7 +221,7 @@ document.addEventListener('DOMContentLoaded', () => {
             showIncrease(gemInc);
           }
           setTimeout(heroAttack, 2000);
-        }, 1000);
+        }, 2000);
       }, 2000);
     } else {
       streak = 0;


### PR DESCRIPTION
## Summary
- Align streak label text to the left and use lower-case "in a row"
- Show reward counter after a 2s delay and start hero attack without extra wait

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1e38d7244832992e246ddf4c06c3d