### PR TITLE
refactor: centralize character stats

### DIFF
--- a/data/characters.json
+++ b/data/characters.json
@@ -1,0 +1,4 @@
+{
+  "shellfin": { "name": "Shellfin", "attack": 1, "health": 5, "gems": 0, "damage": 0 },
+  "octomurk": { "name": "Octomurk", "attack": 1, "health": 5, "damage": 0 }
+}

--- a/data/variables.json
+++ b/data/variables.json
@@ -1,16 +1,8 @@
 {
   "config": {
     "streakGoal": 10,
-    "hero": { "attack": 1, "health": 5, "gems": 0, "damage": 0, "name": "Hero" },
-    "monster": { "attack": 1, "health": 5, "damage": 0, "name": "Monster" }
-  },
-  "characters": {
-    "heroes": {
-      "shellfin": { "name": "Shellfin", "attack": 1, "health": 5 }
-    },
-    "monsters": {
-      "octomurk": { "name": "Octomurk", "attack": 1, "health": 5 }
-    }
+    "selectedHero": "shellfin",
+    "selectedMonster": "octomurk"
   },
   "missions": {
     "Walkthrough": {

--- a/js/battle.js
+++ b/js/battle.js
@@ -60,32 +60,22 @@ document.addEventListener('DOMContentLoaded', () => {
     const data = window.preloadedData;
     const config = data.config || {};
     STREAK_GOAL = Number(config.streakGoal) || STREAK_GOAL;
-    if (config.hero) {
-      hero.attack = Number(config.hero.attack) || hero.attack;
-      hero.health = Number(config.hero.health) || hero.health;
-      hero.gems = Number(config.hero.gems) || hero.gems;
-      hero.damage = Number(config.hero.damage) || hero.damage;
-      hero.name = config.hero.name || hero.name;
+    const heroData = data.characters?.[config.selectedHero];
+    const monsterData = data.characters?.[config.selectedMonster];
+    if (heroData) {
+      hero.attack = Number(heroData.attack) || hero.attack;
+      hero.health = Number(heroData.health) || hero.health;
+      hero.gems = Number(heroData.gems) || hero.gems;
+      hero.damage = Number(heroData.damage) || hero.damage;
+      hero.name = heroData.name || hero.name;
     }
-    if (config.monster) {
-      monster.attack = Number(config.monster.attack) || monster.attack;
-      monster.health = Number(config.monster.health) || monster.health;
-      monster.damage = Number(config.monster.damage) || monster.damage;
-      monster.name = config.monster.name || monster.name;
+    if (monsterData) {
+      monster.attack = Number(monsterData.attack) || monster.attack;
+      monster.health = Number(monsterData.health) || monster.health;
+      monster.damage = Number(monsterData.damage) || monster.damage;
+      monster.name = monsterData.name || monster.name;
     }
-    if (data && data.characters && data.missions) {
-      const heroData = data.characters.heroes?.shellfin;
-      const monsterData = data.characters.monsters?.octomurk;
-      if (heroData) {
-        hero.attack = Number(heroData.attack) || hero.attack;
-        hero.health = Number(heroData.health) || hero.health;
-        hero.name = heroData.name || hero.name;
-      }
-      if (monsterData) {
-        monster.attack = Number(monsterData.attack) || monster.attack;
-        monster.health = Number(monsterData.health) || monster.health;
-        monster.name = monsterData.name || monster.name;
-      }
+    if (data && data.missions) {
       questions = shuffle(data.missions.Walkthrough?.questions || []);
     }
     attackVal.textContent = hero.attack;

--- a/js/loader.js
+++ b/js/loader.js
@@ -1,14 +1,17 @@
 (async function() {
   try {
-    const [varsRes, questionRes] = await Promise.all([
+    const [varsRes, questionRes, charRes] = await Promise.all([
       fetch('../data/variables.json'),
-      fetch('../data/questions.json')
+      fetch('../data/questions.json'),
+      fetch('../data/characters.json')
     ]);
     const varsData = await varsRes.json();
     const questionData = await questionRes.json();
+    const charactersData = await charRes.json();
     if (!varsData.missions) varsData.missions = {};
     if (!varsData.missions.Walkthrough) varsData.missions.Walkthrough = {};
     varsData.missions.Walkthrough.questions = questionData || [];
+    varsData.characters = charactersData || {};
     window.preloadedData = varsData;
     document.dispatchEvent(new Event('data-loaded'));
   } catch (e) {


### PR DESCRIPTION
## Summary
- move hero and monster stats into new data/characters.json
- reference characters via IDs in variables config and battle loader
- load character data dynamically in loader and battle

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1f12f3fb48329af0d17b70d1f9a62