### PR TITLE
Double hero damage after five-answer streak

### DIFF
--- a/js/battle.js
+++ b/js/battle.js
@@ -137,8 +137,8 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   }
 
-  function showIncrease(el) {
-    el.textContent = '+1';
+  function showIncrease(el, text) {
+    el.textContent = text;
     el.classList.remove('show');
     void el.offsetWidth;
     el.classList.add('show');
@@ -201,17 +201,30 @@ document.addEventListener('DOMContentLoaded', () => {
           if (stat === 'attack') {
             hero.attack++;
             attackVal.textContent = hero.attack;
-            showIncrease(attackInc);
+            showIncrease(attackInc, '+1');
           } else if (stat === 'health') {
             hero.health++;
             healthVal.textContent = hero.health;
-            showIncrease(healthInc);
+            showIncrease(healthInc, '+1');
             updateHealthBars();
           } else {
             hero.gems++;
             gemVal.textContent = hero.gems;
-            showIncrease(gemInc);
+            showIncrease(gemInc, '+1');
           }
+
+          if (streak >= STREAK_GOAL) {
+            hero.attack *= 2;
+            attackVal.textContent = hero.attack;
+            if (stat === 'attack') {
+              setTimeout(() => showIncrease(attackInc, 'x2'), 500);
+            } else {
+              showIncrease(attackInc, 'x2');
+            }
+            streak = 0;
+            updateStreak();
+          }
+
           setTimeout(() => {
             document.dispatchEvent(new Event('close-question'));
             heroAttack();


### PR DESCRIPTION
## Summary
- Double hero attack when five answers are correct in a row, resetting the streak
- Restore random +1 rewards for attack, health, or gems after each correct answer
- Display "x2" overlay for doubled attack and "+1" overlay for random rewards

## Testing
- `node --check js/battle.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1f75947f08329ac59e51a8b2d9a42