### PR TITLE
Fix stat increase message after answering correctly

### DIFF
--- a/js/battle.js
+++ b/js/battle.js
@@ -17,6 +17,8 @@ document.addEventListener('DOMContentLoaded', () => {
   const healthVal = questionBox.querySelector('.health .value');
   const gemVal = questionBox.querySelector('.gem .value');
   const attackInc = questionBox.querySelector('.attack .increase');
+  const healthInc = questionBox.querySelector('.health .increase');
+  const gemInc = questionBox.querySelector('.gem .increase');
 
   const levelMessage = document.getElementById('level-message');
   const levelText = levelMessage.querySelector('p');
@@ -195,8 +197,17 @@ document.addEventListener('DOMContentLoaded', () => {
         streak++;
         updateStreak();
         setTimeout(() => {
+          const stats = ['attack', 'health', 'gem'];
+          const stat = stats[Math.floor(Math.random() * stats.length)];
+
           if (streak >= STREAK_GOAL) {
             hero.attack *= 2;
+            attackVal.textContent = hero.attack;
+            showIncrease(attackInc, 'x2');
+            streak = 0;
+            updateStreak();
+          } else if (stat === 'attack') {
+            hero.attack++;
             attackVal.textContent = hero.attack;
             showIncrease(attackInc, '+1');
           } else if (stat === 'health') {
@@ -208,18 +219,6 @@ document.addEventListener('DOMContentLoaded', () => {
             hero.gems++;
             gemVal.textContent = hero.gems;
             showIncrease(gemInc, '+1');
-          }
-
-          if (streak >= STREAK_GOAL) {
-            hero.attack *= 2;
-            attackVal.textContent = hero.attack;
-            if (stat === 'attack') {
-              setTimeout(() => showIncrease(attackInc, 'x2'), 500);
-            } else {
-              showIncrease(attackInc, 'x2');
-            }
-            streak = 0;
-            updateStreak();
           }
 
           setTimeout(() => {


### PR DESCRIPTION
## Summary
- Randomly select a stat (attack, health, gem) to award after a correct answer
- Display `+1` or `x2` stat increase messages and update hero stats accordingly
- Define health and gem increase elements so the `+1` indicators show for all stats

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1fa4a0b7c8329834234b0aea56272