### PR TITLE
Add mission complete stats and check animation

### DIFF
--- a/css/battle.css
+++ b/css/battle.css
@@ -264,16 +264,36 @@
   margin: 0;
 }
 
+#complete-message .enemy-wrapper {
+  position: relative;
+}
+
 #complete-message .enemy-image {
   width: 100%;
   max-width: 200px;
   height: auto;
   opacity: 1;
-  transition: opacity 0.5s ease;
+  filter: saturate(100%);
+  transition: opacity 0.5s ease, filter 0.5s ease;
 }
 
-#complete-message .enemy-image.fade-out {
+#complete-message .enemy-image.dimmed {
+  opacity: 0.1;
+  filter: saturate(0%);
+}
+
+#complete-message .check-icon {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%) scale(0);
   opacity: 0;
+  transition: transform 0.3s ease, opacity 0.3s ease;
+}
+
+#complete-message .check-icon.show {
+  transform: translate(-50%, -50%) scale(1);
+  opacity: 1;
 }
 
 #complete-message .level-box {

--- a/html/battle.html
+++ b/html/battle.html
@@ -69,7 +69,10 @@
     <div id="complete-message">
       <div class="content">
         <h1>Mission Complete</h1>
-        <img class="enemy-image" src="../images/battle/monster_battle.png" alt="Enemy" />
+        <div class="enemy-wrapper">
+          <img class="enemy-image" src="../images/battle/monster_battle.png" alt="Enemy" />
+          <img class="check-icon" src="../images/complete/check.svg" alt="Complete" />
+        </div>
         <div class="level-box">
           <p class="level-title">Level 1</p>
           <div class="progress-bar"><div class="progress-fill"></div></div>

--- a/js/battle.js
+++ b/js/battle.js
@@ -33,6 +33,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const progressFill2 = completeMessage?.querySelector('.progress-fill');
   const accuracyValue = completeMessage?.querySelector('.accuracy-value');
   const speedValue = completeMessage?.querySelector('.speed-value');
+  const checkIcon = completeMessage?.querySelector('.check-icon');
   const nextBattleBtn = completeMessage?.querySelector('.next-battle-btn');
 
   let STREAK_GOAL = 5;
@@ -336,16 +337,9 @@ document.addEventListener('DOMContentLoaded', () => {
       if (completeEnemyImg) {
         completeEnemyImg.src = monsterImg.src;
         setTimeout(() => {
-          completeEnemyImg.classList.add('fade-out');
-          completeEnemyImg.addEventListener(
-            'transitionend',
-            () => {
-              completeEnemyImg.src = '../images/battle/monster_complete.png';
-              completeEnemyImg.classList.remove('fade-out');
-            },
-            { once: true }
-          );
-        }, 2000);
+          completeEnemyImg.classList.add('dimmed');
+          if (checkIcon) checkIcon.classList.add('show');
+        }, 1000);
       }
       if (progressFill2) progressFill2.style.width = '100%';
       if (levelTitle) levelTitle.textContent = 'Level 1';


### PR DESCRIPTION
## Summary
- Display Accuracy and Speed stats on mission completion.
- Dim defeated enemy and animate completion check mark.

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c4f3566f648329a674ee656533b0ce