### PR TITLE
Rename battle completion stats boxes to level boxes

### DIFF
--- a/css/battle.css
+++ b/css/battle.css
@@ -321,14 +321,14 @@
   transition: width 0.5s ease-in-out;
 }
 
-#complete-message .stats {
+#complete-message .level-boxes {
   width: 100%;
   height: 100%;
   display: flex;
   gap: 16px;
 }
 
-#complete-message .stat-box {
+#complete-message .level-boxes .level-box {
   flex: 1;
   background: #F6F6F6;
   border-radius: 8px;
@@ -340,14 +340,14 @@
   gap: 8px;
 }
 
-#complete-message .stat-box .label {
+#complete-message .level-boxes .level-box .label {
   font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
   font-size: 14px;
   color: #858585;
   margin: 0;
 }
 
-#complete-message .stat-box .value {
+#complete-message .level-boxes .level-box .value {
   font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
   font-size: 24px;
   color: #006AFF;

--- a/html/battle.html
+++ b/html/battle.html
@@ -77,12 +77,12 @@
           <p class="level-title">Level 1</p>
           <div class="progress-bar"><div class="progress-fill"></div></div>
         </div>
-        <div class="stats">
-          <div class="stat-box">
+        <div class="level-boxes">
+          <div class="level-box">
             <p class="label">Accuracy</p>
             <p class="value accuracy-value">0%</p>
           </div>
-          <div class="stat-box">
+          <div class="level-box">
             <p class="label">Speed</p>
             <p class="value speed-value">0s</p>
           </div>


### PR DESCRIPTION
## Summary
- Rename battle completion stat boxes to level boxes
- Update completion message container class to `level-boxes` for clarity

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c4f8b4cae0832996d0e5f522ecaa90