### PR TITLE
Hide streak progress until first correct answer

### DIFF
--- a/css/question.css
+++ b/css/question.css
@@ -68,6 +68,17 @@
 #question .top-bar {
   width: 100%;
   align-items: center;
+  display: flex;
+  visibility: hidden;
+  opacity: 0;
+  transform: translateY(10px);
+  transition: opacity 0.3s ease, transform 0.3s ease;
+}
+
+#question .top-bar.show {
+  visibility: visible;
+  opacity: 1;
+  transform: translateY(0);
 }
 
 #question .progress-wrap {

--- a/js/battle.js
+++ b/js/battle.js
@@ -11,6 +11,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const questionBox = document.getElementById('question');
   const questionText = questionBox.querySelector('p');
   const choicesEl = questionBox.querySelector('.choices');
+  const topBar = questionBox.querySelector('.top-bar');
   const progressBar = questionBox.querySelector('.progress-bar');
   const progressFill = questionBox.querySelector('.progress-fill');
   const streakLabel = questionBox.querySelector('.streak-label');
@@ -159,36 +160,46 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function updateStreak() {
     const percent = Math.min(streak / STREAK_GOAL, 1) * 100;
-    progressFill.style.width = percent + '%';
-    progressBar.classList.add('with-label');
-    if (streakMaxed) {
-      progressFill.style.background = '#FF6A00';
-      streakLabel.textContent = '2x Attack';
-      streakLabel.style.color = '#FF6A00';
-      streakLabel.classList.remove('show');
-      void streakLabel.offsetWidth;
-      streakLabel.classList.add('show');
-      if (streakIcon && !streakIconShown) {
-        progressFill.addEventListener(
-          'transitionend',
-          () => {
-            streakIcon.classList.add('show');
-          },
-          { once: true }
-        );
-        streakIconShown = true;
-      }
-    } else {
-      progressFill.style.background = '#006AFF';
-      streakLabel.style.color = '#006AFF';
-      streakLabel.textContent = `${streak} in a row`;
-      if (streak > 0) {
+    if (streak > 0) {
+      topBar?.classList.add('show');
+      progressBar.classList.add('with-label');
+      void progressFill.offsetWidth;
+      progressFill.style.width = percent + '%';
+      if (streakMaxed) {
+        progressFill.style.background = '#FF6A00';
+        streakLabel.textContent = '2x Attack';
+        streakLabel.style.color = '#FF6A00';
         streakLabel.classList.remove('show');
         void streakLabel.offsetWidth;
         streakLabel.classList.add('show');
+        if (streakIcon && !streakIconShown) {
+          progressFill.addEventListener(
+            'transitionend',
+            () => {
+              streakIcon.classList.add('show');
+            },
+            { once: true }
+          );
+          streakIconShown = true;
+        }
       } else {
+        progressFill.style.background = '#006AFF';
+        streakLabel.style.color = '#006AFF';
+        streakLabel.textContent = `${streak} in a row`;
         streakLabel.classList.remove('show');
+        void streakLabel.offsetWidth;
+        streakLabel.classList.add('show');
+        if (streakIcon) {
+          streakIcon.classList.remove('show');
+        }
+        streakIconShown = false;
       }
+    } else {
+      topBar?.classList.remove('show');
+      progressBar.classList.remove('with-label');
+      progressFill.style.width = '0%';
+      progressFill.style.background = '#006AFF';
+      streakLabel.classList.remove('show');
       if (streakIcon) {
         streakIcon.classList.remove('show');
       }


### PR DESCRIPTION
## Summary
- Keep streak progress bar space reserved with visibility/opacity so layout doesn't shift.
- Slide the progress bar and streak label into view after the first correct answer.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c4f7c0bec883298b06b04e2c6955e1