### PR TITLE
Hide question top bar until streak

### DIFF
--- a/css/question.css
+++ b/css/question.css
@@ -40,13 +40,14 @@
   color: #888888;
 }
 
-#question p {
+#question .question-text {
   font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
   font-size: 24px;
   margin: 0;
   padding: 0;
   color: #272B34;
   width: 100%;
+  padding-top: 16px;
 }
 
 #question button {
@@ -68,7 +69,7 @@
 #question .top-bar {
   width: 100%;
   align-items: center;
-  display: flex;
+  display: none;
   visibility: hidden;
   opacity: 0;
   transform: translateY(10px);
@@ -76,9 +77,14 @@
 }
 
 #question .top-bar.show {
+  display: flex;
   visibility: visible;
   opacity: 1;
   transform: translateY(0);
+}
+
+#question .top-bar.show + .question-text {
+  padding-top: 0;
 }
 
 #question .progress-wrap {

--- a/html/battle.html
+++ b/html/battle.html
@@ -61,7 +61,7 @@
             </div>
           </div>
         </div>
-        <p></p>
+        <p class="question-text"></p>
         <div class="choices"></div>
         <button type="button">Submit</button>
       </div>

--- a/js/battle.js
+++ b/js/battle.js
@@ -9,7 +9,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const heroStats = document.getElementById('shellfin-stats');
 
   const questionBox = document.getElementById('question');
-  const questionText = questionBox.querySelector('p');
+  const questionText = questionBox.querySelector('.question-text');
   const choicesEl = questionBox.querySelector('.choices');
   const topBar = questionBox.querySelector('.top-bar');
   const progressBar = questionBox.querySelector('.progress-bar');


### PR DESCRIPTION
## Summary
- hide question top bar by default and reveal only when streak starts, removing layout impact
- add `question-text` styling with 16px top padding and automatically drop padding when top bar appears
- update battle script to target new `question-text` element

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c5a59c11748329a26e8419e06ed087