### PR TITLE
Celebrate streaks with pop-in boosts and delay

### DIFF
--- a/css/battle.css
+++ b/css/battle.css
@@ -80,7 +80,7 @@
 
 .stat-box .stat .increase {
   position: absolute;
-  top: 0px;
+  top: -10px;
   right: -5px;
   font-size: 20px;
   font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
@@ -89,13 +89,27 @@
   border-radius: 8px;
   padding: 6px 12px;
   opacity: 0;
-  transform: translateY(0);
-  transition: opacity 0.3s, transform 0.3s;
+  transform: scale(0);
+  pointer-events: none;
 }
 
 .stat-box .stat .increase.show {
-  opacity: 1;
-  transform: translateY(-7.5px);
+  animation: increase-pop 0.6s forwards;
+}
+
+@keyframes increase-pop {
+  0% {
+    opacity: 0;
+    transform: scale(0);
+  }
+  60% {
+    opacity: 1;
+    transform: scale(1.3);
+  }
+  100% {
+    opacity: 1;
+    transform: scale(1);
+  }
 }
 
 .hp-bar {

--- a/js/battle.js
+++ b/js/battle.js
@@ -317,13 +317,15 @@ document.addEventListener('DOMContentLoaded', () => {
 
       // Keep the question visible briefly so the player can
       // see the result and streak progress before it closes.
+      // If the streak just hit the goal (x2), linger a bit longer.
+      const lingerTime = incText === 'x2' ? 4000 : 2000;
       setTimeout(() => {
         document.dispatchEvent(new Event('close-question'));
         setTimeout(() => {
           showIncrease(incEl, incText);
           setTimeout(heroAttack, 1000);
         }, 300);
-      }, 2000);
+      }, lingerTime);
     } else {
       streak = 0;
       streakMaxed = false;


### PR DESCRIPTION
## Summary
- Animate stat increase badges with a kid-friendly pop-in bounce
- Pause for an extra 2s before battle when the streak hits 5 to celebrate

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c5a877d8888329b902b3c506376341