### PR TITLE
Reset streak after double attack

### DIFF
--- a/js/battle.js
+++ b/js/battle.js
@@ -227,6 +227,12 @@ document.addEventListener('DOMContentLoaded', () => {
       setTimeout(() => {
         monster.damage += hero.attack;
         updateHealthBars();
+        if (streakMaxed) {
+          // Double-attack was used; reset streak.
+          streak = 0;
+          streakMaxed = false;
+          updateStreak();
+        }
         setTimeout(() => {
           if (monster.damage >= monster.health) {
             endBattle(true);


### PR DESCRIPTION
## Summary
- reset hero's streak after consuming 5-streak double attack while keeping doubled attack value

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c5ae14c3908329ba06a714a9db8bfb