### PR TITLE
Animate landing hero and add level preview overlay

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -24,10 +24,10 @@ main.landing {
   left: 50%;
   width: min(320px, 55vw);
   max-width: 360px;
-  transform: translate(-250%, 0);
+  transform: translate(150%, 0);
   animation-name: hero-slide, hero-float;
   animation-duration: 1.5s, 3.5s;
-  animation-timing-function: ease-out, ease-in-out;
+  animation-timing-function: cubic-bezier(0.22, 0.61, 0.36, 1), ease-in-out;
   animation-delay: 0s, 1.5s;
   animation-fill-mode: forwards, both;
   animation-iteration-count: 1, infinite;
@@ -38,7 +38,7 @@ main.landing {
 
 @keyframes hero-slide {
   0% {
-    transform: translate(-250%, 0);
+    transform: translate(150%, 0);
   }
   100% {
     transform: translate(-50%, 0);
@@ -75,7 +75,7 @@ main.landing {
   border-radius: 50%;
   opacity: 0;
   animation: bubble-rise var(--duration) ease-in infinite;
-  animation-delay: calc(1.5s + var(--delay));
+  animation-delay: var(--delay);
   filter: blur(0.25px);
 }
 
@@ -122,6 +122,8 @@ main.landing {
   animation: message-pop 0.5s ease-out forwards;
   animation-delay: 2.2s;
   z-index: 3;
+  cursor: pointer;
+  transition: transform 0.6s ease, opacity 0.6s ease;
 }
 
 @keyframes message-pop {
@@ -166,6 +168,131 @@ main.landing {
   transform: translateX(32px);
 }
 
+.message-card:focus-visible {
+  outline: 3px solid #006aff;
+  outline-offset: 4px;
+}
+
+.message-card:active {
+  transform: translate(-50%, 4px) scale(0.98);
+}
+
+body.level-open {
+  overflow: hidden;
+}
+
+body.level-open .message-card {
+  transform: translate(-50%, -40vh) scale(1.2);
+  opacity: 0;
+  pointer-events: none;
+}
+
+.level-overlay {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  background: rgba(22, 28, 38, 0.25);
+  opacity: 0;
+  transform: translateY(48px);
+  pointer-events: none;
+  transition: opacity 0.6s ease, transform 0.6s ease;
+  z-index: 5;
+}
+
+.level-overlay .level-card {
+  width: min(420px, 100%);
+  padding: 28px;
+  border-radius: 16px;
+  background: #fff;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 28px;
+  box-shadow: 0 24px 54px rgba(17, 30, 52, 0.35);
+  transform: translateY(24px) scale(0.95);
+  transition: transform 0.6s ease;
+}
+
+.level-overlay .progress-bar {
+  width: 100%;
+  height: 16px;
+  background: #f4f6fa;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.level-overlay .progress-fill {
+  width: var(--progress-current, 0%);
+  height: 100%;
+  background: linear-gradient(90deg, #00a1ff 0%, #006aff 100%);
+  transition: width 0.6s ease;
+}
+
+.level-overlay .level-info {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+}
+
+.level-overlay .level-title {
+  margin: 0;
+  font-size: 20px;
+  color: #9c9c9c;
+}
+
+.level-overlay .math-type {
+  margin: 0;
+  font-size: 36px;
+  color: #272b34;
+}
+
+.level-overlay .enemy-image {
+  width: min(220px, 60%);
+  height: auto;
+}
+
+.level-overlay .btn-primary {
+  width: 100%;
+  height: 64px;
+  background: #006aff;
+  color: #fff;
+  border: none;
+  border-radius: 12px;
+  font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
+  font-size: 20px;
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.level-overlay .btn-primary:focus-visible {
+  outline: 3px solid #00a1ff;
+  outline-offset: 2px;
+}
+
+.level-overlay .btn-primary:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 28px rgba(0, 106, 255, 0.35);
+}
+
+body.level-open .level-overlay {
+  opacity: 1;
+  transform: translateY(0);
+  pointer-events: auto;
+}
+
+body.level-open .level-overlay .level-card {
+  transform: translateY(0) scale(1);
+}
+
+body.level-open .level-overlay .progress-fill {
+  width: var(--progress-target, 0%);
+}
+
 @media (max-width: 720px) {
   .hero {
     bottom: 36vh;
@@ -192,13 +319,25 @@ main.landing {
     height: 160px;
     transform: none;
   }
+
+  body.level-open .message-card {
+    transform: translate(-50%, -35vh) scale(1.15);
+  }
+
+  .level-overlay .math-type {
+    font-size: 30px;
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {
   .hero,
   .bubble,
-  .message-card {
+  .message-card,
+  .level-overlay,
+  .level-overlay .level-card,
+  .level-overlay .btn-primary {
     animation: none;
+    transition: none;
   }
 
   .hero {
@@ -213,5 +352,9 @@ main.landing {
     position: static;
     margin: 16px;
     transform: none;
+  }
+
+  body.level-open {
+    overflow: auto;
   }
 }

--- a/index.html
+++ b/index.html
@@ -25,7 +25,14 @@
       alt="Shellfin swimming into view"
     />
 
-    <aside class="message-card" aria-live="polite">
+    <aside
+      class="message-card"
+      role="button"
+      tabindex="0"
+      aria-live="polite"
+      aria-controls="level-overlay"
+      aria-expanded="false"
+    >
       <div class="message-text">
         <p class="message-title">Addition</p>
         <p class="message-subtitle">Battle 1</p>
@@ -36,6 +43,24 @@
         alt="Enemy monster ready for battle"
       />
     </aside>
+    <div id="level-overlay" class="level-overlay" aria-hidden="true">
+      <div class="level-card" role="dialog" aria-modal="true" aria-labelledby="level-overlay-title">
+        <div class="progress-bar">
+          <div class="progress-fill"></div>
+        </div>
+        <div class="level-info">
+          <p id="level-overlay-title" class="level-title level-number">Level 1</p>
+          <p class="math-type">Addition</p>
+        </div>
+        <img
+          class="enemy-image"
+          src="images/battle/monster_battle.png"
+          alt="Enemy monster ready for battle"
+        />
+        <button class="btn-primary battle-btn" type="button">Battle</button>
+      </div>
+    </div>
   </main>
+  <script src="js/index.js" defer></script>
 </body>
 </html>

--- a/js/index.js
+++ b/js/index.js
@@ -1,0 +1,139 @@
+const initLandingInteractions = () => {
+  const messageCard = document.querySelector('.message-card');
+  const levelOverlay = document.getElementById('level-overlay');
+  const battleButton = levelOverlay?.querySelector('.battle-btn');
+  const progressFill = levelOverlay?.querySelector('.progress-fill');
+  const messageTitle = messageCard?.querySelector('.message-title');
+  const messageSubtitle = messageCard?.querySelector('.message-subtitle');
+  const messageEnemy = messageCard?.querySelector('.message-enemy');
+  const overlayLevel = levelOverlay?.querySelector('.level-number');
+  const overlayMath = levelOverlay?.querySelector('.math-type');
+  const overlayEnemy = levelOverlay?.querySelector('.enemy-image');
+  const progressBar = levelOverlay?.querySelector('.progress-bar');
+
+  if (!messageCard || !levelOverlay) {
+    return;
+  }
+
+  const loadLevelPreview = async () => {
+    try {
+      const response = await fetch('data/levels.json');
+      const data = await response.json();
+      const [firstLevel] = data.levels ?? [];
+
+      if (!firstLevel) {
+        return;
+      }
+
+      const { id, math, enemySprite, progress } = firstLevel;
+      const enemyPath = `images/${enemySprite}`;
+
+      if (messageTitle) {
+        messageTitle.textContent = math;
+      }
+
+      if (messageSubtitle) {
+        messageSubtitle.textContent = `Battle ${id}`;
+      }
+
+      if (messageEnemy) {
+        messageEnemy.src = enemyPath;
+      }
+
+      if (overlayLevel) {
+        overlayLevel.textContent = `Level ${id}`;
+      }
+
+      if (overlayMath) {
+        overlayMath.textContent = math;
+      }
+
+      if (overlayEnemy) {
+        overlayEnemy.src = enemyPath;
+      }
+
+      const safeProgress = Math.max(0, Math.min(progress ?? 0, 1));
+      const progressPercent = safeProgress * 100;
+      const percentLabel = `${Math.round(progressPercent * 10) / 10}%`;
+
+      if (progressFill) {
+        progressFill.style.setProperty('--progress-target', percentLabel);
+      }
+
+      if (progressBar && progressFill) {
+        progressBar.setAttribute('role', 'progressbar');
+        progressBar.setAttribute('aria-label', 'Level progress');
+        progressBar.setAttribute('aria-valuemin', '0');
+        progressBar.setAttribute('aria-valuemax', '100');
+        progressBar.setAttribute('aria-valuenow', `${Math.round(progressPercent)}`);
+      }
+    } catch (error) {
+      console.error('Failed to load level preview', error);
+    }
+  };
+
+  loadLevelPreview();
+
+  const openOverlay = () => {
+    if (document.body.classList.contains('level-open')) {
+      return;
+    }
+
+    document.body.classList.add('level-open');
+    levelOverlay.setAttribute('aria-hidden', 'false');
+    messageCard.setAttribute('aria-expanded', 'true');
+
+    window.setTimeout(() => {
+      battleButton?.focus({ preventScroll: true });
+    }, 400);
+
+    if (progressBar && progressFill) {
+      const target = progressFill.style.getPropertyValue('--progress-target') || '0%';
+      progressBar.setAttribute('aria-valuenow', target.replace('%', ''));
+    }
+  };
+
+  const closeOverlay = () => {
+    if (!document.body.classList.contains('level-open')) {
+      return;
+    }
+
+    document.body.classList.remove('level-open');
+    levelOverlay.setAttribute('aria-hidden', 'true');
+    messageCard.setAttribute('aria-expanded', 'false');
+    messageCard.focus({ preventScroll: true });
+  };
+
+  messageCard.addEventListener('click', openOverlay);
+
+  messageCard.addEventListener('keydown', (event) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      openOverlay();
+    }
+  });
+
+  levelOverlay.addEventListener('click', (event) => {
+    if (event.target === levelOverlay) {
+      closeOverlay();
+    }
+  });
+
+  document.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape') {
+      closeOverlay();
+    }
+  });
+
+  if (battleButton) {
+    battleButton.addEventListener('click', () => {
+      window.location.href = 'html/battle.html';
+    });
+  }
+};
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initLandingInteractions);
+} else {
+  initLandingInteractions();
+}


### PR DESCRIPTION
## Summary
- animate the landing hero to arrive from the right, retime the bubbles, and enhance motion cues
- turn the message card into an interactive control that opens a level-style overlay with smooth transitions
- populate the overlay from level data and forward players to the battle screen from the preview

## Testing
- Not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68c88610f620832991f6e6fef8134d04