### PR TITLE
Update landing transitions and level preview UI

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -24,13 +24,9 @@ main.landing {
   left: 50%;
   max-width: 300px;
   max-height: 300px;
-  transform: translate(-250%, 0);
-  animation-name: hero-slide, hero-float;
-  animation-duration: 1.5s, 3.5s;
-  animation-timing-function: cubic-bezier(0.22, 0.61, 0.36, 1), ease-in-out;
-  animation-delay: 0s, 1.5s;
-  animation-fill-mode: forwards, both;
-  animation-iteration-count: 1, infinite;
+  transform: translateX(150%);
+  animation: hero-slide 1.35s cubic-bezier(0.22, 0.61, 0.36, 1) forwards,
+    hero-float 3.5s ease-in-out 1.35s infinite;
   image-rendering: auto;
   z-index: 2;
   pointer-events: none;
@@ -38,22 +34,25 @@ main.landing {
 
 @keyframes hero-slide {
   0% {
-    transform: translate(150%, 0);
+    transform: translateX(150%);
+  }
+  80% {
+    transform: translateX(-54%);
   }
   100% {
-    transform: translate(-50%, 0);
+    transform: translateX(-50%);
   }
 }
 
 @keyframes hero-float {
   0% {
-    transform: translate(-50%, 0);
+    transform: translateX(-50%) translateY(0);
   }
   50% {
-    transform: translate(-50%, -16px);
+    transform: translateX(-50%) translateY(-16px);
   }
   100% {
-    transform: translate(-50%, 0);
+    transform: translateX(-50%) translateY(0);
   }
 }
 
@@ -66,40 +65,80 @@ main.landing {
 }
 
 .bubble {
+  --drift: 0px;
   position: absolute;
   bottom: -80px;
   left: var(--left);
   width: var(--size);
   height: var(--size);
-  background: rgba(255, 255, 255, 0.55);
+  background: radial-gradient(
+      circle at 32% 32%,
+      rgba(255, 255, 255, 0.45) 0%,
+      rgba(255, 255, 255, 0.18) 35%,
+      rgba(255, 255, 255, 0.05) 60%,
+      rgba(255, 255, 255, 0) 100%
+    );
   border-radius: 50%;
+  border: 2px solid rgba(255, 255, 255, 0.75);
   opacity: 0;
   animation: bubble-rise var(--duration) ease-in infinite;
   animation-delay: var(--delay);
-  filter: blur(0.25px);
+  box-shadow: inset 0 0 12px rgba(255, 255, 255, 0.25);
+  filter: blur(0.2px);
 }
 
+.bubble:nth-of-type(odd) {
+  --drift: 10px;
+}
+
+.bubble:nth-of-type(3n) {
+  --drift: -8px;
+}
+
+.bubble::before,
 .bubble::after {
   content: '';
   position: absolute;
-  inset: 20%;
   border-radius: 50%;
-  background: rgba(255, 255, 255, 0.3);
+  pointer-events: none;
+}
+
+.bubble::before {
+  top: 18%;
+  left: 22%;
+  width: 28%;
+  height: 28%;
+  background: rgba(255, 255, 255, 0.85);
+  filter: blur(2px);
+  opacity: 0.85;
+}
+
+.bubble::after {
+  inset: 12%;
+  border-radius: 50%;
+  background: radial-gradient(
+    circle at 50% 40%,
+    rgba(255, 255, 255, 0.35) 0%,
+    rgba(255, 255, 255, 0.15) 45%,
+    rgba(255, 255, 255, 0.05) 70%,
+    rgba(255, 255, 255, 0) 100%
+  );
+  filter: blur(1.25px);
 }
 
 @keyframes bubble-rise {
   0% {
-    transform: translateY(0) scale(0.7);
+    transform: translate3d(0, 0, 0) scale(0.68);
     opacity: 0;
   }
-  15% {
-    opacity: 0.5;
+  20% {
+    opacity: 0.55;
   }
-  40% {
-    opacity: 0.8;
+  45% {
+    opacity: 0.92;
   }
   100% {
-    transform: translateY(-110vh) scale(1.05);
+    transform: translate3d(var(--drift, 0px), -110vh, 0) scale(1.06);
     opacity: 0;
   }
 }
@@ -118,13 +157,14 @@ main.landing {
   gap: 24px;
   align-items: flex-start;
   text-align: left;
-  overflow:hidden;
+  overflow: hidden;
   box-shadow: 0 18px 36px rgba(0, 0, 0, 0.25);
   animation: message-pop 0.5s ease-out forwards;
   animation-delay: 2.2s;
   z-index: 3;
   cursor: pointer;
   transition: transform 0.6s ease, opacity 0.6s ease;
+  visibility: visible;
 }
 
 @keyframes message-pop {
@@ -176,6 +216,12 @@ main.landing {
   transform: translate(-50%, 4px) scale(0.98);
 }
 
+.message-card--hidden {
+  visibility: hidden;
+  pointer-events: none;
+  display: none;
+}
+
 body.level-open {
   overflow: hidden;
 }
@@ -203,55 +249,74 @@ body.level-open .message-card {
 
 .level-overlay .level-card {
   width: min(420px, 100%);
-  padding: 28px;
+  padding: 32px 32px 36px;
   border-radius: 16px;
   background: #fff;
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 28px;
+  gap: 24px;
   box-shadow: 0 24px 54px rgba(17, 30, 52, 0.35);
   transform: translateY(24px) scale(0.95);
   transition: transform 0.6s ease;
-}
-
-.level-overlay .progress-bar {
-  width: 100%;
-  height: 16px;
-  background: #f4f6fa;
-  border-radius: 8px;
-  overflow: hidden;
-}
-
-.level-overlay .progress-fill {
-  width: var(--progress-current, 0%);
-  height: 100%;
-  background: linear-gradient(90deg, #00a1ff 0%, #006aff 100%);
-  transition: width 0.6s ease;
 }
 
 .level-overlay .level-info {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 8px;
-}
-
-.level-overlay .level-title {
-  margin: 0;
-  font-size: 20px;
-  color: #9c9c9c;
+  gap: 6px;
 }
 
 .level-overlay .math-type {
   margin: 0;
-  font-size: 36px;
+  font-size: 18px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: #778099;
+}
+
+.level-overlay .battle-title {
+  margin: 0;
+  font-size: 40px;
+  font-weight: 700;
   color: #272b34;
 }
 
 .level-overlay .enemy-image {
   width: min(220px, 60%);
   height: auto;
+}
+
+.level-overlay .battle-stats {
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 16px 20px;
+  background: rgba(0, 48, 120, 0.08);
+  border-radius: 12px;
+}
+
+.level-overlay .battle-stat {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+}
+
+.level-overlay .stat-label {
+  font-size: 14px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: #7a859b;
+}
+
+.level-overlay .stat-value {
+  font-size: 28px;
+  font-weight: 700;
+  color: #1d2433;
 }
 
 .level-overlay .btn-primary {
@@ -286,8 +351,4 @@ body.level-open .level-overlay {
 
 body.level-open .level-overlay .level-card {
   transform: translateY(0) scale(1);
-}
-
-body.level-open .level-overlay .progress-fill {
-  width: var(--progress-target, 0%);
 }

--- a/css/level.css
+++ b/css/level.css
@@ -1,86 +1,134 @@
 body {
   margin: 0;
-  height: 100vh;
+  min-height: 100vh;
   display: flex;
   align-items: center;
   justify-content: center;
   background: url('../images/background/background.png') no-repeat center/cover;
   font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
+  color: #272b34;
+}
+
+main.level-screen {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  padding: 32px 16px;
+  box-sizing: border-box;
 }
 
 .level-message {
-  background: #fff;
-  border-radius: 8px;
-  padding: 24px;
-  width: 100%;
-  max-width: 400px;
-  box-sizing: border-box;
+  width: min(440px, 100%);
+  background: rgba(255, 255, 255, 0.96);
+  border-radius: 16px;
+  padding: 36px 32px 40px;
+  box-shadow: 0 24px 54px rgba(17, 30, 52, 0.35);
   text-align: center;
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: 24px;
-  animation: pop-in 0.3s ease-out;
-}
-
-.level-message .level-title {
-  font-size: 20px;
-  color: #9C9C9C;
-  margin: 0;
-}
-
-.level-message .progress-bar {
-  width: 100%;
-  height: 16px;
-  background: #F4F6FA;
-  border-radius: 4px;
-  overflow: hidden;
-}
-
-.level-message .progress-fill {
-  width: 0%;
-  height: 100%;
-  background: #006AFF;
-  transition: width 0.5s ease-in-out;
+  animation: pop-in 0.4s ease-out;
 }
 
 .level-message .level-info {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 8px;
+  gap: 6px;
 }
 
 .level-message .math-type {
-  font-size: 32px;
-  color: #272B34;
   margin: 0;
+  font-size: 18px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: #778099;
+}
+
+.level-message .battle-title {
+  margin: 0;
+  font-size: 40px;
+  font-weight: 700;
+  color: #272b34;
 }
 
 .level-message .enemy-image {
-  width: 100%;
-  max-width: 200px;
+  width: min(240px, 65%);
   height: auto;
+}
+
+.level-message .battle-stats {
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 16px 20px;
+  background: rgba(0, 48, 120, 0.08);
+  border-radius: 12px;
+}
+
+.level-message .battle-stat {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+}
+
+.level-message .stat-label {
+  font-size: 14px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: #7a859b;
+}
+
+.level-message .stat-value {
+  font-size: 28px;
+  font-weight: 700;
+  color: #1d2433;
 }
 
 .btn-primary {
   width: 100%;
   height: 64px;
-  background: #006AFF;
+  background: #006aff;
   color: #fff;
   border: none;
-  border-radius: 8px;
+  border-radius: 12px;
   font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
   font-size: 20px;
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.btn-primary:focus-visible {
+  outline: 3px solid #00a1ff;
+  outline-offset: 2px;
+}
+
+.btn-primary:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 28px rgba(0, 106, 255, 0.35);
 }
 
 .btn-primary:disabled {
-  background: #D2D8E2;
-  color: #272B34;
+  background: #d2d8e2;
+  color: #272b34;
 }
 
 @keyframes pop-in {
-  0% { transform: scale(0.8); opacity: 0; }
-  80% { transform: scale(1.05); opacity: 1; }
-  100% { transform: scale(1); opacity: 1; }
+  0% {
+    transform: scale(0.88);
+    opacity: 0;
+  }
+  80% {
+    transform: scale(1.04);
+    opacity: 1;
+  }
+  100% {
+    transform: scale(1);
+    opacity: 1;
+  }
 }

--- a/html/level.html
+++ b/html/level.html
@@ -7,15 +7,34 @@
   <link rel="stylesheet" href="../css/level.css" />
 </head>
 <body>
-  <div class="level-message">
-    <div class="progress-bar"><div class="progress-fill"></div></div>
-    <div class="level-info">
-      <p class="level-title level-number">Level 1</p>
-      <p class="math-type">Addition</p>
-    </div>
-    <img class="enemy-image" src="../images/battle/monster_battle.png" alt="Enemy" />
-    <button class="btn-primary battle-btn">Battle</button>
-  </div>
+  <main class="level-screen">
+    <section
+      class="level-message"
+      aria-labelledby="level-screen-battle level-screen-math"
+      aria-describedby="level-screen-stats"
+    >
+      <div class="level-info">
+        <p id="level-screen-math" class="math-type">Addition</p>
+        <p id="level-screen-battle" class="battle-title">Battle 1</p>
+      </div>
+      <img
+        class="enemy-image"
+        src="../images/battle/monster_battle.png"
+        alt="Enemy monster ready for battle"
+      />
+      <div id="level-screen-stats" class="battle-stats" aria-live="polite">
+        <div class="battle-stat">
+          <span class="stat-label">Accuracy</span>
+          <span class="stat-value accuracy-value">0</span>
+        </div>
+        <div class="battle-stat">
+          <span class="stat-label">Time</span>
+          <span class="stat-value time-value">0</span>
+        </div>
+      </div>
+      <button class="btn-primary battle-btn" type="button">Let's Battle</button>
+    </section>
+  </main>
   <script src="../js/level.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -44,20 +44,33 @@
       />
     </aside>
     <div id="level-overlay" class="level-overlay" aria-hidden="true">
-      <div class="level-card" role="dialog" aria-modal="true" aria-labelledby="level-overlay-title">
-        <div class="progress-bar">
-          <div class="progress-fill"></div>
-        </div>
+      <div
+        class="level-card"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="level-overlay-battle level-overlay-math"
+        aria-describedby="level-overlay-stats"
+      >
         <div class="level-info">
-          <p id="level-overlay-title" class="level-title level-number">Level 1</p>
-          <p class="math-type">Addition</p>
+          <p id="level-overlay-math" class="math-type">Addition</p>
+          <p id="level-overlay-battle" class="battle-title">Battle 1</p>
         </div>
         <img
           class="enemy-image"
           src="images/battle/monster_battle.png"
           alt="Enemy monster ready for battle"
         />
-        <button class="btn-primary battle-btn" type="button">Battle</button>
+        <div id="level-overlay-stats" class="battle-stats" aria-live="polite">
+          <div class="battle-stat">
+            <span class="stat-label">Accuracy</span>
+            <span class="stat-value accuracy-value">0</span>
+          </div>
+          <div class="battle-stat">
+            <span class="stat-label">Time</span>
+            <span class="stat-value time-value">0</span>
+          </div>
+        </div>
+        <button class="btn-primary battle-btn" type="button">Let's Battle</button>
       </div>
     </div>
   </main>

--- a/js/index.js
+++ b/js/index.js
@@ -2,18 +2,21 @@ const initLandingInteractions = () => {
   const messageCard = document.querySelector('.message-card');
   const levelOverlay = document.getElementById('level-overlay');
   const battleButton = levelOverlay?.querySelector('.battle-btn');
-  const progressFill = levelOverlay?.querySelector('.progress-fill');
   const messageTitle = messageCard?.querySelector('.message-title');
   const messageSubtitle = messageCard?.querySelector('.message-subtitle');
   const messageEnemy = messageCard?.querySelector('.message-enemy');
-  const overlayLevel = levelOverlay?.querySelector('.level-number');
   const overlayMath = levelOverlay?.querySelector('.math-type');
   const overlayEnemy = levelOverlay?.querySelector('.enemy-image');
-  const progressBar = levelOverlay?.querySelector('.progress-bar');
+  const overlayBattleTitle = levelOverlay?.querySelector('.battle-title');
+  const overlayAccuracy = levelOverlay?.querySelector('.accuracy-value');
+  const overlayTime = levelOverlay?.querySelector('.time-value');
 
   if (!messageCard || !levelOverlay) {
     return;
   }
+
+  const defaultTabIndex = messageCard.getAttribute('tabindex') ?? '0';
+  let hideMessageCardTimeout;
 
   const loadLevelPreview = async () => {
     try {
@@ -25,47 +28,39 @@ const initLandingInteractions = () => {
         return;
       }
 
-      const { id, math, enemySprite, progress } = firstLevel;
-      const enemyPath = `images/${enemySprite}`;
+      const { id, math, enemySprite } = firstLevel;
+      const enemyPath = typeof enemySprite === 'string' ? `images/${enemySprite}` : '';
 
-      if (messageTitle) {
+      if (messageTitle && typeof math === 'string') {
         messageTitle.textContent = math;
       }
 
-      if (messageSubtitle) {
+      if (messageSubtitle && typeof id !== 'undefined') {
         messageSubtitle.textContent = `Battle ${id}`;
       }
 
-      if (messageEnemy) {
+      if (messageEnemy && enemyPath) {
         messageEnemy.src = enemyPath;
       }
 
-      if (overlayLevel) {
-        overlayLevel.textContent = `Level ${id}`;
-      }
-
-      if (overlayMath) {
+      if (overlayMath && typeof math === 'string') {
         overlayMath.textContent = math;
       }
 
-      if (overlayEnemy) {
+      if (overlayBattleTitle && typeof id !== 'undefined') {
+        overlayBattleTitle.textContent = `Battle ${id}`;
+      }
+
+      if (overlayEnemy && enemyPath) {
         overlayEnemy.src = enemyPath;
       }
 
-      const safeProgress = Math.max(0, Math.min(progress ?? 0, 1));
-      const progressPercent = safeProgress * 100;
-      const percentLabel = `${Math.round(progressPercent * 10) / 10}%`;
-
-      if (progressFill) {
-        progressFill.style.setProperty('--progress-target', percentLabel);
+      if (overlayAccuracy) {
+        overlayAccuracy.textContent = '0';
       }
 
-      if (progressBar && progressFill) {
-        progressBar.setAttribute('role', 'progressbar');
-        progressBar.setAttribute('aria-label', 'Level progress');
-        progressBar.setAttribute('aria-valuemin', '0');
-        progressBar.setAttribute('aria-valuemax', '100');
-        progressBar.setAttribute('aria-valuenow', `${Math.round(progressPercent)}`);
+      if (overlayTime) {
+        overlayTime.textContent = '0';
       }
     } catch (error) {
       console.error('Failed to load level preview', error);
@@ -79,18 +74,22 @@ const initLandingInteractions = () => {
       return;
     }
 
+    window.clearTimeout(hideMessageCardTimeout);
+    messageCard.classList.remove('message-card--hidden');
+
     document.body.classList.add('level-open');
     levelOverlay.setAttribute('aria-hidden', 'false');
     messageCard.setAttribute('aria-expanded', 'true');
+    messageCard.setAttribute('aria-hidden', 'true');
+    messageCard.setAttribute('tabindex', '-1');
 
     window.setTimeout(() => {
       battleButton?.focus({ preventScroll: true });
     }, 400);
 
-    if (progressBar && progressFill) {
-      const target = progressFill.style.getPropertyValue('--progress-target') || '0%';
-      progressBar.setAttribute('aria-valuenow', target.replace('%', ''));
-    }
+    hideMessageCardTimeout = window.setTimeout(() => {
+      messageCard.classList.add('message-card--hidden');
+    }, 620);
   };
 
   const closeOverlay = () => {
@@ -98,10 +97,17 @@ const initLandingInteractions = () => {
       return;
     }
 
+    window.clearTimeout(hideMessageCardTimeout);
+    messageCard.classList.remove('message-card--hidden');
     document.body.classList.remove('level-open');
     levelOverlay.setAttribute('aria-hidden', 'true');
     messageCard.setAttribute('aria-expanded', 'false');
-    messageCard.focus({ preventScroll: true });
+    messageCard.setAttribute('aria-hidden', 'false');
+    messageCard.setAttribute('tabindex', defaultTabIndex);
+
+    window.setTimeout(() => {
+      messageCard.focus({ preventScroll: true });
+    }, 520);
   };
 
   messageCard.addEventListener('click', openOverlay);

--- a/js/level.js
+++ b/js/level.js
@@ -1,18 +1,44 @@
 document.addEventListener('DOMContentLoaded', async () => {
+  const mathType = document.querySelector('.math-type');
+  const battleTitle = document.querySelector('.battle-title');
+  const enemyImage = document.querySelector('.enemy-image');
+  const accuracyValue = document.querySelector('.accuracy-value');
+  const timeValue = document.querySelector('.time-value');
+  const battleButton = document.querySelector('.battle-btn');
+
   try {
     const res = await fetch('../data/levels.json');
     const data = await res.json();
-    const current = data.levels[0];
+    const [current] = data.levels ?? [];
 
-    document.querySelector('.level-number').textContent = `Level ${current.id}`;
-    document.querySelector('.math-type').textContent = current.math;
-    document.querySelector('.enemy-image').src = `../images/${current.enemySprite}`;
-    document.querySelector('.progress-fill').style.width = `${current.progress * 100}%`;
+    if (current) {
+      const { id, math, enemySprite } = current;
+
+      if (mathType && typeof math === 'string') {
+        mathType.textContent = math;
+      }
+
+      if (battleTitle && typeof id !== 'undefined') {
+        battleTitle.textContent = `Battle ${id}`;
+      }
+
+      if (enemyImage && typeof enemySprite === 'string') {
+        enemyImage.src = `../images/${enemySprite}`;
+      }
+    }
+
+    if (accuracyValue) {
+      accuracyValue.textContent = '0';
+    }
+
+    if (timeValue) {
+      timeValue.textContent = '0';
+    }
   } catch (e) {
     console.error('Failed to load level data', e);
   }
 
-  document.querySelector('.battle-btn').addEventListener('click', () => {
+  battleButton?.addEventListener('click', () => {
     window.location.href = 'battle.html';
   });
 });


### PR DESCRIPTION
## Summary
- animate the landing hero so it enters from the right and refresh the bubble visuals for a glassier look
- hide the landing message card during the transition and redesign the level overlay with new battle stats and button copy
- restyle the standalone level screen to match the updated overlay and simplify the supporting JavaScript data hooks

## Testing
- Not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68c88a20b4d48329ad804c2467a068cf