### PR TITLE
Enhance landing visuals and overlay flow

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -71,19 +71,43 @@ main.landing {
   left: var(--left);
   width: var(--size);
   height: var(--size);
-  background: radial-gradient(
-      circle at 32% 32%,
-      rgba(255, 255, 255, 0.18) 0%,
-      rgba(255, 255, 255, 0.05) 35%,
-      rgba(255, 255, 255, 0.05) 60%,
+  background:
+    radial-gradient(
+      circle at 26% 28%,
+      rgba(255, 255, 255, 0.95) 0%,
+      rgba(255, 255, 255, 0.5) 18%,
+      rgba(255, 255, 255, 0.12) 46%,
+      rgba(255, 255, 255, 0) 70%
+    ),
+    radial-gradient(
+      circle at 74% 32%,
+      rgba(255, 255, 255, 0.7) 0%,
+      rgba(255, 255, 255, 0.34) 16%,
+      rgba(255, 255, 255, 0.05) 45%,
+      rgba(255, 255, 255, 0) 70%
+    ),
+    radial-gradient(
+      circle at 50% 52%,
+      rgba(182, 229, 255, 0.6) 0%,
+      rgba(141, 210, 255, 0.32) 35%,
+      rgba(109, 156, 255, 0.2) 58%,
+      rgba(255, 255, 255, 0.45) 72%,
+      rgba(255, 255, 255, 0.08) 88%,
       rgba(255, 255, 255, 0) 100%
     );
   border-radius: 50%;
   opacity: 0;
+  border: 1.5px solid rgba(255, 255, 255, 0.85);
+  box-shadow:
+    inset 0 0 28px rgba(255, 255, 255, 0.45),
+    inset 0 0 48px rgba(96, 185, 255, 0.25),
+    0 14px 32px rgba(13, 76, 146, 0.24);
   animation: bubble-rise var(--duration) ease-in infinite;
   animation-delay: var(--delay);
-  box-shadow: inset 0 0 12px rgba(255, 255, 255, 0.25);
-  filter: blur(0.2px);
+  filter: drop-shadow(0 12px 22px rgba(8, 44, 96, 0.25)) saturate(1.05);
+  backdrop-filter: blur(0.5px);
+  will-change: transform, opacity;
+  isolation: isolate;
 }
 
 .bubble:nth-of-type(odd) {
@@ -104,25 +128,39 @@ main.landing {
 
 .bubble::before {
   top: 18%;
-  left: 22%;
-  width: 28%;
-  height: 28%;
-  background: rgba(255, 255, 255, 0.85);
-  filter: blur(2px);
-  opacity: 0.85;
+  left: 18%;
+  width: 36%;
+  height: 36%;
+  background: radial-gradient(
+    circle at 35% 35%,
+    rgba(255, 255, 255, 0.95) 0%,
+    rgba(255, 255, 255, 0.65) 32%,
+    rgba(255, 255, 255, 0.25) 60%,
+    rgba(255, 255, 255, 0) 100%
+  );
+  filter: blur(1.4px);
+  opacity: 0.95;
+  transform: rotate(-15deg);
+  animation: bubble-highlight calc(var(--duration) * 0.8) ease-in-out infinite;
 }
 
 .bubble::after {
-  inset: 12%;
+  inset: 10%;
   border-radius: 50%;
-  background: radial-gradient(
-    circle at 50% 40%,
-    rgba(255, 255, 255, 0.35) 0%,
-    rgba(255, 255, 255, 0.15) 45%,
-    rgba(255, 255, 255, 0.05) 70%,
-    rgba(255, 255, 255, 0) 100%
+  background: conic-gradient(
+    from 150deg at 50% 50%,
+    rgba(255, 255, 255, 0.2) 0deg,
+    rgba(110, 191, 255, 0.45) 70deg,
+    rgba(255, 171, 220, 0.35) 150deg,
+    rgba(120, 227, 255, 0.35) 230deg,
+    rgba(255, 255, 255, 0.22) 300deg,
+    rgba(255, 255, 255, 0.2) 360deg
   );
-  filter: blur(1.25px);
+  filter: blur(6px);
+  mix-blend-mode: screen;
+  opacity: 0.85;
+  transform-origin: 50% 50%;
+  animation: bubble-sheen calc(var(--duration) * 1.3) linear infinite;
 }
 
 @keyframes bubble-rise {
@@ -130,15 +168,51 @@ main.landing {
     transform: translate3d(0, 0, 0) scale(0.68);
     opacity: 0;
   }
-  20% {
-    opacity: 0.55;
+  15% {
+    transform: translate3d(calc(var(--drift, 0px) * 0.18), -18vh, 0) scale(0.82)
+      rotate(-3deg);
+    opacity: 0.48;
   }
-  45% {
-    opacity: 0.92;
+  35% {
+    transform: translate3d(calc(var(--drift, 0px) * 0.45), -42vh, 0) scale(0.95)
+      rotate(2deg);
+    opacity: 0.94;
+  }
+  55% {
+    transform: translate3d(calc(var(--drift, 0px) * 0.7), -72vh, 0) scale(1.04)
+      rotate(-1.5deg);
+    opacity: 0.98;
   }
   100% {
-    transform: translate3d(var(--drift, 0px), -110vh, 0) scale(1.06);
+    transform: translate3d(var(--drift, 0px), -110vh, 0) scale(1.08)
+      rotate(0deg);
     opacity: 0;
+  }
+}
+
+@keyframes bubble-highlight {
+  0%,
+  100% {
+    transform: translate3d(0, 0, 0) scale(1) rotate(-15deg);
+    opacity: 0.95;
+  }
+  50% {
+    transform: translate3d(6%, -8%, 0) scale(1.12) rotate(10deg);
+    opacity: 0.7;
+  }
+}
+
+@keyframes bubble-sheen {
+  0% {
+    transform: rotate(0deg) scale(1);
+    opacity: 0.85;
+  }
+  45% {
+    opacity: 0.7;
+  }
+  100% {
+    transform: rotate(360deg) scale(1.05);
+    opacity: 0.85;
   }
 }
 
@@ -164,6 +238,7 @@ main.landing {
   cursor: pointer;
   transition: transform 0.6s ease, opacity 0.6s ease;
   visibility: visible;
+  will-change: transform, opacity, box-shadow;
 }
 
 @keyframes message-pop {
@@ -178,6 +253,25 @@ main.landing {
   100% {
     transform: translate(-50%, 0) scale(1);
     opacity: 1;
+  }
+}
+
+@keyframes message-card-activate {
+  0% {
+    transform: translate(-50%, 0) scale(1);
+    box-shadow: 0 18px 36px rgba(0, 0, 0, 0.25);
+  }
+  45% {
+    transform: translate(-50%, -28px) scale(1.08);
+    box-shadow: 0 32px 54px rgba(17, 30, 52, 0.35);
+  }
+  70% {
+    transform: translate(-50%, -8px) scale(1.02);
+    box-shadow: 0 24px 44px rgba(13, 34, 66, 0.28);
+  }
+  100% {
+    transform: translate(-50%, 0) scale(1);
+    box-shadow: 0 20px 40px rgba(0, 0, 0, 0.26);
   }
 }
 
@@ -213,6 +307,12 @@ main.landing {
 
 .message-card:active {
   transform: translate(-50%, 4px) scale(0.98);
+}
+
+.message-card--activating {
+  animation: message-card-activate 0.45s cubic-bezier(0.34, 1.56, 0.64, 1);
+  pointer-events: none;
+  z-index: 4;
 }
 
 .message-card--hidden {
@@ -292,28 +392,68 @@ body.level-open .message-card {
   display: flex;
   justify-content: space-between;
   gap: 16px;
-  padding: 16px 20px;
-  background: rgba(0, 48, 120, 0.08);
-  border-radius: 12px;
+  padding: 0;
+  background: transparent;
 }
 
 .level-overlay .battle-stat {
+  position: relative;
   flex: 1;
   display: flex;
   flex-direction: column;
-  align-items: center;
-  gap: 6px;
+  align-items: flex-start;
+  justify-content: center;
+  gap: 8px;
+  padding: 18px 20px;
+  min-height: 96px;
+  border-radius: 14px;
+  background: linear-gradient(
+    145deg,
+    rgba(255, 255, 255, 0.92),
+    rgba(216, 231, 255, 0.88)
+  );
+  border: 1px solid rgba(126, 164, 221, 0.35);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.75),
+    0 16px 32px rgba(22, 53, 102, 0.18);
+  backdrop-filter: blur(6px);
+  overflow: hidden;
+  text-align: left;
+}
+
+.level-overlay .battle-stat::before {
+  content: '';
+  position: absolute;
+  inset: -55% 30% 55% -40%;
+  background: linear-gradient(125deg, rgba(255, 255, 255, 0.55), transparent);
+  opacity: 0.9;
+  transform: rotate(8deg);
+  pointer-events: none;
+}
+
+.level-overlay .battle-stat::after {
+  content: '';
+  position: absolute;
+  inset: 20% -30% -40% 45%;
+  background: radial-gradient(
+    circle at 20% 20%,
+    rgba(255, 255, 255, 0.65),
+    rgba(255, 255, 255, 0)
+  );
+  opacity: 0.6;
+  pointer-events: none;
+  transform: rotate(-12deg);
 }
 
 .level-overlay .stat-label {
-  font-size: 14px;
+  font-size: 13px;
   letter-spacing: 0.1em;
   text-transform: uppercase;
-  color: #7a859b;
+  color: #6e7b95;
 }
 
 .level-overlay .stat-value {
-  font-size: 28px;
+  font-size: 30px;
   font-weight: 700;
   color: #1d2433;
 }

--- a/js/index.js
+++ b/js/index.js
@@ -17,6 +17,8 @@ const initLandingInteractions = () => {
 
   const defaultTabIndex = messageCard.getAttribute('tabindex') ?? '0';
   let hideMessageCardTimeout;
+  let activateOverlayTimeout;
+  const MESSAGE_CARD_POP_DURATION = 450;
 
   const loadLevelPreview = async () => {
     try {
@@ -70,26 +72,34 @@ const initLandingInteractions = () => {
   loadLevelPreview();
 
   const openOverlay = () => {
-    if (document.body.classList.contains('level-open')) {
+    if (
+      document.body.classList.contains('level-open') ||
+      messageCard.classList.contains('message-card--activating')
+    ) {
       return;
     }
 
     window.clearTimeout(hideMessageCardTimeout);
+    window.clearTimeout(activateOverlayTimeout);
     messageCard.classList.remove('message-card--hidden');
-
-    document.body.classList.add('level-open');
-    levelOverlay.setAttribute('aria-hidden', 'false');
+    messageCard.classList.add('message-card--activating');
     messageCard.setAttribute('aria-expanded', 'true');
-    messageCard.setAttribute('aria-hidden', 'true');
-    messageCard.setAttribute('tabindex', '-1');
 
-    window.setTimeout(() => {
-      battleButton?.focus({ preventScroll: true });
-    }, 400);
+    activateOverlayTimeout = window.setTimeout(() => {
+      messageCard.classList.remove('message-card--activating');
+      document.body.classList.add('level-open');
+      levelOverlay.setAttribute('aria-hidden', 'false');
+      messageCard.setAttribute('aria-hidden', 'true');
+      messageCard.setAttribute('tabindex', '-1');
 
-    hideMessageCardTimeout = window.setTimeout(() => {
-      messageCard.classList.add('message-card--hidden');
-    }, 620);
+      window.setTimeout(() => {
+        battleButton?.focus({ preventScroll: true });
+      }, 400);
+
+      hideMessageCardTimeout = window.setTimeout(() => {
+        messageCard.classList.add('message-card--hidden');
+      }, 620);
+    }, MESSAGE_CARD_POP_DURATION);
   };
 
   const closeOverlay = () => {
@@ -98,6 +108,8 @@ const initLandingInteractions = () => {
     }
 
     window.clearTimeout(hideMessageCardTimeout);
+    window.clearTimeout(activateOverlayTimeout);
+    messageCard.classList.remove('message-card--activating');
     messageCard.classList.remove('message-card--hidden');
     document.body.classList.remove('level-open');
     levelOverlay.setAttribute('aria-hidden', 'true');


### PR DESCRIPTION
## Summary
- restyle the landing page bubbles with layered gradients, highlights, and motion for a realistic look
- add a pop-out activation animation for the message card before revealing the level overlay
- redesign the level stats section into two glassy cards for Accuracy and Time

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68c89088c39483299e4833f024e80e5c