### PR TITLE
Animate message card out before level overlay

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -211,6 +211,17 @@ main.landing {
   visibility: visible;
 }
 
+/* Prevent rapid re-triggering while the card is animating */
+.message-card--animating {
+  pointer-events: none;
+}
+
+body.message-exiting .message-card {
+  transform: translate(-50%, -40vh) scale(1.2);
+  opacity: 0;
+  pointer-events: none;
+}
+
 @keyframes message-pop {
   0%   { transform: translate(-50%, calc(100% + 16px)) scale(0.8); opacity: 0; }
   60%  { transform: translate(-50%, -8px) scale(1.05); opacity: 1; }
@@ -228,11 +239,6 @@ main.landing {
 .message-card--hidden { visibility: hidden; pointer-events: none; display: none; }
 
 body.level-open { overflow: hidden; }
-body.level-open .message-card {
-  transform: translate(-50%, -40vh) scale(1.2);
-  opacity: 0;
-  pointer-events: none;
-}
 
 .level-overlay {
   position: fixed;
@@ -306,5 +312,9 @@ body.level-open .level-overlay .level-card { transform: translateY(0) scale(1); 
 @media (prefers-reduced-motion: reduce) {
   .bubble { animation: none; opacity: 0.35; }
   .hero { animation: none; transform: translateX(-50%); }
-  .message-card { animation: none; }
+  .message-card {
+    animation: none;
+    transform: translate(-50%, 0) scale(1);
+    opacity: 1;
+  }
 }


### PR DESCRIPTION
## Summary
- add a message-exiting body state so the landing message card animates out before the level overlay fades in
- gate interactions in the index script to wait for the exit animation to finish before showing or hiding the overlay
- tweak reduced motion styles to keep the message card visible when animations are disabled

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68c8962bb25c8329aebec6c0ada10a7f