### PR TITLE
Adjust landing card layout and overlay stats

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -193,7 +193,7 @@ main.landing {
   bottom: 16px;
   max-height: 120px;
   transform: translate(-50%, calc(100% + 16px)) scale(0.9);
-  min-width: 400px;
+  width: min(480px, calc(100% - 32px));
   padding: 24px;
   border-radius: 16px;
   background: rgba(255, 255, 255, 0.96);
@@ -204,11 +204,15 @@ main.landing {
   overflow: hidden;
   box-shadow: 0 18px 36px rgba(0, 0, 0, 0.25);
   animation: message-pop 0.5s ease-out forwards;
-  animation-delay: 2.2s;
+  animation-delay: var(--message-card-delay, 2.2s);
   z-index: 3;
   cursor: pointer;
   transition: transform 0.6s ease, opacity 0.6s ease;
   visibility: visible;
+}
+
+.message-card--no-delay {
+  --message-card-delay: 0s;
 }
 
 /* Prevent rapid re-triggering while the card is animating */
@@ -277,14 +281,20 @@ body.level-open { overflow: hidden; }
 .level-overlay .battle-stats {
   width: 100%;
   display: flex;
-  justify-content: space-between;
   gap: 16px;
+}
+
+.level-overlay .battle-stat {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
   padding: 16px 20px;
   background: rgba(0, 48, 120, 0.08);
   border-radius: 12px;
 }
-
-.level-overlay .battle-stat { flex: 1; display: flex; flex-direction: column; align-items: center; gap: 6px; }
 .level-overlay .stat-label { font-size: 14px; letter-spacing: 0.1em; text-transform: uppercase; color: #7a859b; }
 .level-overlay .stat-value { font-size: 28px; font-weight: 700; color: #1d2433; }
 

--- a/js/index.js
+++ b/js/index.js
@@ -119,6 +119,7 @@ const initLandingInteractions = () => {
     levelOverlay.setAttribute('aria-hidden', 'true');
     messageCard.classList.remove('message-card--hidden');
     messageCard.classList.add('message-card--animating');
+    messageCard.classList.add('message-card--no-delay');
     messageCard.setAttribute('aria-expanded', 'false');
     messageCard.setAttribute('aria-hidden', 'false');
     messageCard.setAttribute('tabindex', defaultTabIndex);


### PR DESCRIPTION
## Summary
- ensure the landing page message card respects a 16px viewport margin and remove the animation delay after it reappears
- style the level preview stats as individual horizontal boxes for accuracy and time
- update the interaction script so the message card resumes instantly when the overlay closes

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68c8b5a233c083299809ce4b0b90ff0e