### PR TITLE
Align battle flows with shared card styling

### DIFF
--- a/css/battle-card.css
+++ b/css/battle-card.css
@@ -1,23 +1,4 @@
-body {
-  margin: 0;
-  min-height: 100vh;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: url('../images/background/background.png') no-repeat center/cover;
-  font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
-  color: #272b34;
-}
-
-main.level-screen {
-  width: 100%;
-  display: flex;
-  justify-content: center;
-  padding: 32px 16px;
-  box-sizing: border-box;
-}
-
-.level-message {
+.battle-card {
   width: min(440px, 100%);
   background: rgba(255, 255, 255, 0.96);
   border-radius: 16px;
@@ -31,14 +12,14 @@ main.level-screen {
   animation: pop-in 0.4s ease-out;
 }
 
-.level-message .level-info {
+.battle-card .battle-info {
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: 6px;
 }
 
-.level-message .math-type {
+.battle-card .math-type {
   margin: 0;
   font-size: 18px;
   letter-spacing: 0.12em;
@@ -46,19 +27,19 @@ main.level-screen {
   color: #778099;
 }
 
-.level-message .battle-title {
+.battle-card .battle-title {
   margin: 0;
   font-size: 40px;
   font-weight: 700;
   color: #272b34;
 }
 
-.level-message .enemy-image {
+.battle-card .enemy-image {
   width: min(240px, 65%);
   height: auto;
 }
 
-.level-message .battle-stats {
+.battle-card .battle-stats {
   width: 100%;
   display: flex;
   justify-content: space-between;
@@ -68,22 +49,23 @@ main.level-screen {
   border-radius: 12px;
 }
 
-.level-message .battle-stat {
+.battle-card .battle-stat {
   flex: 1;
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: 6px;
+  min-width: 0;
 }
 
-.level-message .stat-label {
+.battle-card .stat-label {
   font-size: 14px;
   letter-spacing: 0.1em;
   text-transform: uppercase;
   color: #7a859b;
 }
 
-.level-message .stat-value {
+.battle-card .stat-value {
   font-size: 28px;
   font-weight: 700;
   color: #1d2433;

--- a/css/battle-intro.css
+++ b/css/battle-intro.css
@@ -1,0 +1,18 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: url('../images/background/background.png') no-repeat center/cover;
+  font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
+  color: #272b34;
+}
+
+main.battle-intro {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  padding: 32px 16px;
+  box-sizing: border-box;
+}

--- a/css/battle.css
+++ b/css/battle.css
@@ -166,25 +166,7 @@
   100% { transform: translateX(0); }
 }
 
-#set-streak-btn {
-  position: fixed;
-  top: 8px;
-  right: 8px;
-  z-index: 1000;
-  font-size: 12px;
-  padding: 4px 8px;
-}
-
-#kill-enemy-btn {
-  position: fixed;
-  top: 40px;
-  right: 8px;
-  z-index: 1000;
-  font-size: 12px;
-  padding: 4px 8px;
-}
-
-#level-message {
+#battle-message {
   position: absolute;
   top: 0;
   left: 0;
@@ -200,33 +182,22 @@
   z-index: 30;
 }
 
-#level-message.show {
+#battle-message.show {
   opacity: 1;
   visibility: visible;
 }
 
-#level-message .content {
+#battle-message .content {
   background: #fff;
   padding: 24px;
   border-radius: 8px;
   text-align: center;
 }
 
-#level-message .content p {
+#battle-message .content p {
   font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
   font-size: 24px;
   margin: 0 0 16px;
-}
-
-#level-message .content button {
-  width: 100%;
-  height: 64px;
-  background: #006AFF;
-  color: #fff;
-  border: none;
-  border-radius: 8px;
-  font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
-  font-size: 20px;
 }
 
 #complete-message {
@@ -250,120 +221,8 @@
   visibility: visible;
 }
 
-#complete-message .battle-complete-card {
+#complete-message .battle-card {
   width: min(440px, 90%);
-  background: rgba(255, 255, 255, 0.96);
-  border-radius: 16px;
-  padding: 36px 32px 40px;
-  box-shadow: 0 24px 54px rgba(17, 30, 52, 0.35);
-  text-align: center;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 24px;
-  animation: pop-in 0.4s ease-out;
-}
-
-#complete-message .battle-complete-card .level-info {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 6px;
-}
-
-#complete-message .battle-complete-card .math-type {
-  margin: 0;
-  font-size: 18px;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  color: #778099;
-}
-
-#complete-message .battle-complete-card .battle-title {
-  margin: 0;
-  font-size: 40px;
-  font-weight: 700;
-  color: #272b34;
-}
-
-#complete-message .battle-complete-card .enemy-image {
-  width: min(240px, 65%);
-  height: auto;
-}
-
-#complete-message .battle-complete-card .battle-stats {
-  width: 100%;
-  display: flex;
-  justify-content: space-between;
-  gap: 16px;
-  padding: 16px 20px;
-  background: rgba(0, 48, 120, 0.08);
-  border-radius: 12px;
-}
-
-#complete-message .battle-complete-card .battle-stat {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 6px;
-}
-
-#complete-message .battle-complete-card .stat-label {
-  font-size: 14px;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
-  color: #7a859b;
-}
-
-#complete-message .battle-complete-card .stat-value {
-  font-size: 28px;
-  font-weight: 700;
-  color: #1d2433;
-}
-
-.btn-primary {
-  width: 100%;
-  height: 64px;
-  background: #006aff;
-  color: #fff;
-  border: none;
-  border-radius: 12px;
-  font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
-  font-size: 20px;
-  letter-spacing: 0.02em;
-  cursor: pointer;
-  transition: transform 0.3s ease, box-shadow 0.3s ease;
-}
-
-.btn-primary:focus-visible {
-  outline: 3px solid #00a1ff;
-  outline-offset: 2px;
-}
-
-.btn-primary:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 12px 28px rgba(0, 106, 255, 0.35);
-}
-
-.btn-primary:disabled {
-  background: #d2d8e2;
-  color: #272b34;
-}
-
-@keyframes pop-in {
-  0% {
-    transform: scale(0.88);
-    opacity: 0;
-  }
-  80% {
-    transform: scale(1.04);
-    opacity: 1;
-  }
-  100% {
-    transform: scale(1);
-    opacity: 1;
-  }
 }
 
 .battle-stat-banner {

--- a/css/index.css
+++ b/css/index.css
@@ -242,9 +242,9 @@ body.message-exiting .message-card {
 .message-card:active { transform: translate(-50%, 4px) scale(0.98); }
 .message-card--hidden { visibility: hidden; pointer-events: none; display: none; }
 
-body.level-open { overflow: hidden; }
+body.battle-overlay-open { overflow: hidden; }
 
-.level-overlay {
+.battle-overlay {
   position: fixed;
   inset: 0;
   display: flex;
@@ -259,64 +259,18 @@ body.level-open { overflow: hidden; }
   z-index: 5;
 }
 
-.level-overlay .level-card {
+.battle-overlay .battle-overlay-card {
   width: min(420px, 100%);
   padding: 32px 32px 36px;
-  border-radius: 16px;
-  background: #fff;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 24px;
-  box-shadow: 0 24px 54px rgba(17, 30, 52, 0.35);
   transform: translateY(24px) scale(0.95);
   transition: transform 0.6s ease;
+  animation: none;
 }
 
-.level-overlay .level-info { display: flex; flex-direction: column; align-items: center; gap: 6px; }
-.level-overlay .math-type { margin: 0; font-size: 18px; letter-spacing: 0.12em; text-transform: uppercase; color: #778099; }
-.level-overlay .battle-title { margin: 0; font-size: 40px; font-weight: 700; color: #272b34; }
-.level-overlay .enemy-image { width: min(220px, 60%); height: auto; }
+.battle-overlay .enemy-image { width: min(220px, 60%); height: auto; }
 
-.level-overlay .battle-stats {
-  width: 100%;
-  display: flex;
-  gap: 16px;
-}
-
-.level-overlay .battle-stat {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 6px;
-  min-width: 0;
-  padding: 16px 20px;
-  background: rgba(0, 48, 120, 0.08);
-  border-radius: 12px;
-}
-.level-overlay .stat-label { font-size: 14px; letter-spacing: 0.1em; text-transform: uppercase; color: #7a859b; }
-.level-overlay .stat-value { font-size: 28px; font-weight: 700; color: #1d2433; }
-
-.level-overlay .btn-primary {
-  width: 100%;
-  height: 64px;
-  background: #006aff;
-  color: #fff;
-  border: none;
-  border-radius: 12px;
-  font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
-  font-size: 20px;
-  letter-spacing: 0.02em;
-  cursor: pointer;
-  transition: transform 0.3s ease, box-shadow 0.3s ease;
-}
-
-.level-overlay .btn-primary:focus-visible { outline: 3px solid #00a1ff; outline-offset: 2px; }
-.level-overlay .btn-primary:hover { transform: translateY(-2px); box-shadow: 0 12px 28px rgba(0, 106, 255, 0.35); }
-
-body.level-open .level-overlay { opacity: 1; transform: translateY(0); pointer-events: auto; }
-body.level-open .level-overlay .level-card { transform: translateY(0) scale(1); }
+body.battle-overlay-open .battle-overlay { opacity: 1; transform: translateY(0); pointer-events: auto; }
+body.battle-overlay-open .battle-overlay .battle-overlay-card { transform: translateY(0) scale(1); }
 
 /* Respect reduced motion */
 @media (prefers-reduced-motion: reduce) {

--- a/html/battle-intro.html
+++ b/html/battle-intro.html
@@ -3,26 +3,27 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Level</title>
-  <link rel="stylesheet" href="../css/level.css" />
+  <title>Battle Intro</title>
+  <link rel="stylesheet" href="../css/battle-card.css" />
+  <link rel="stylesheet" href="../css/battle-intro.css" />
 </head>
 <body>
-  <main class="level-screen">
+  <main class="battle-intro">
     <section
-      class="level-message"
-      aria-labelledby="level-screen-battle level-screen-math"
-      aria-describedby="level-screen-stats"
+      class="battle-card"
+      aria-labelledby="battle-intro-title battle-intro-math"
+      aria-describedby="battle-intro-stats"
     >
-      <div class="level-info">
-        <p id="level-screen-math" class="math-type">Addition</p>
-        <p id="level-screen-battle" class="battle-title">Battle 1</p>
+      <div class="battle-info">
+        <p id="battle-intro-math" class="math-type">Addition</p>
+        <p id="battle-intro-title" class="battle-title">Battle 1</p>
       </div>
       <img
         class="enemy-image"
         src="../images/battle/monster_battle.png"
         alt="Enemy monster ready for battle"
       />
-      <div id="level-screen-stats" class="battle-stats" aria-live="polite">
+      <div id="battle-intro-stats" class="battle-stats" aria-live="polite">
         <div class="battle-stat">
           <span class="stat-label">Accuracy</span>
           <span class="stat-value accuracy-value">0</span>
@@ -35,6 +36,6 @@
       <button class="btn-primary battle-btn" type="button">Let's Battle</button>
     </section>
   </main>
-  <script src="../js/level.js"></script>
+  <script src="../js/battle-intro.js"></script>
 </body>
 </html>

--- a/html/battle.html
+++ b/html/battle.html
@@ -1,19 +1,18 @@
-  <!DOCTYPE html>
-  <html lang="en">
+<!DOCTYPE html>
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
     <meta name="theme-color" content="transparent" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
-    <title>Shellfin Intro</title>
+    <title>Battle</title>
     <link rel="stylesheet" href="../css/style.css" />
     <link rel="stylesheet" href="../css/question.css" />
+    <link rel="stylesheet" href="../css/battle-card.css" />
     <link rel="stylesheet" href="../css/battle.css" />
   </head>
   <body>
-  <button id="set-streak-btn" type="button">Set Streak 4</button>
-  <button id="kill-enemy-btn" type="button">Kill Enemy</button>
   <div class="battle-stat-banner" aria-live="polite">
     <div class="stat">
       <span class="label">Accuracy</span>
@@ -77,8 +76,8 @@
       </div>
     </div>
     <div id="complete-message" role="dialog" aria-modal="true" aria-labelledby="battle-complete-title">
-      <section class="level-message battle-complete-card">
-        <div class="level-info">
+      <section class="battle-card battle-complete-card">
+        <div class="battle-info">
           <p class="math-type">Victory</p>
           <p id="battle-complete-title" class="battle-title">Battle Complete</p>
         </div>
@@ -100,16 +99,16 @@
         <button type="button" class="btn-primary next-mission-btn">Next Mission</button>
       </section>
     </div>
-    <div id="level-message">
+    <div id="battle-message">
       <div class="content">
         <p></p>
-        <button type="button">try again</button>
+        <button type="button" class="btn-primary">Try Again</button>
       </div>
     </div>
-      <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
-      <script src="../js/supabaseClient.js"></script>
-      <script src="../js/loader.js"></script>
-      <script src="../js/battle.js"></script>
-      <script src="../js/question.js"></script>
-    </body>
-    </html>
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+    <script src="../js/supabaseClient.js"></script>
+    <script src="../js/loader.js"></script>
+    <script src="../js/battle.js"></script>
+    <script src="../js/question.js"></script>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Reef Rangers</title>
+  <link rel="stylesheet" href="css/battle-card.css" />
   <link rel="stylesheet" href="css/index.css" />
 </head>
 <body>
@@ -30,7 +31,7 @@
       role="button"
       tabindex="0"
       aria-live="polite"
-      aria-controls="level-overlay"
+      aria-controls="battle-overlay"
       aria-expanded="false"
     >
       <div class="message-text">
@@ -43,24 +44,24 @@
         alt="Enemy monster ready for battle"
       />
     </aside>
-    <div id="level-overlay" class="level-overlay" aria-hidden="true">
+    <div id="battle-overlay" class="battle-overlay" aria-hidden="true">
       <div
-        class="level-card"
+        class="battle-card battle-overlay-card"
         role="dialog"
         aria-modal="true"
-        aria-labelledby="level-overlay-battle level-overlay-math"
-        aria-describedby="level-overlay-stats"
+        aria-labelledby="battle-overlay-title battle-overlay-math"
+        aria-describedby="battle-overlay-stats"
       >
-        <div class="level-info">
-          <p id="level-overlay-math" class="math-type">Addition</p>
-          <p id="level-overlay-battle" class="battle-title">Battle 1</p>
+        <div class="battle-info">
+          <p id="battle-overlay-math" class="math-type">Addition</p>
+          <p id="battle-overlay-title" class="battle-title">Battle 1</p>
         </div>
         <img
           class="enemy-image"
           src="images/battle/monster_battle.png"
           alt="Enemy monster ready for battle"
         />
-        <div id="level-overlay-stats" class="battle-stats" aria-live="polite">
+        <div id="battle-overlay-stats" class="battle-stats" aria-live="polite">
           <div class="battle-stat">
             <span class="stat-label">Accuracy</span>
             <span class="stat-value accuracy-value">0</span>

--- a/js/battle-intro.js
+++ b/js/battle-intro.js
@@ -9,10 +9,10 @@ document.addEventListener('DOMContentLoaded', async () => {
   try {
     const res = await fetch('../data/levels.json');
     const data = await res.json();
-    const [current] = data.levels ?? [];
+    const [currentBattle] = data.levels ?? [];
 
-    if (current) {
-      const { id, math, enemySprite } = current;
+    if (currentBattle) {
+      const { id, math, enemySprite } = currentBattle;
 
       if (mathType && typeof math === 'string') {
         mathType.textContent = math;
@@ -35,7 +35,7 @@ document.addEventListener('DOMContentLoaded', async () => {
       timeValue.textContent = '0';
     }
   } catch (e) {
-    console.error('Failed to load level data', e);
+    console.error('Failed to load battle data', e);
   }
 
   battleButton?.addEventListener('click', () => {

--- a/js/battle.js
+++ b/js/battle.js
@@ -16,8 +16,6 @@ document.addEventListener('DOMContentLoaded', () => {
   const progressFill = questionBox.querySelector('.progress-fill');
   const streakLabel = questionBox.querySelector('.streak-label');
   const streakIcon = questionBox.querySelector('.streak-icon');
-  const testButton = document.getElementById('set-streak-btn');
-  const killButton = document.getElementById('kill-enemy-btn');
   const bannerAccuracyValue = document.querySelector('[data-banner-accuracy]');
   const bannerTimeValue = document.querySelector('[data-banner-time]');
   const heroAttackVal = heroStats.querySelector('.attack .value');
@@ -27,9 +25,9 @@ document.addEventListener('DOMContentLoaded', () => {
   const monsterAttackVal = monsterStats.querySelector('.attack .value');
   const monsterHealthVal = monsterStats.querySelector('.health .value');
 
-  const levelMessage = document.getElementById('level-message');
-  const levelText = levelMessage.querySelector('p');
-  const levelButton = levelMessage.querySelector('button');
+  const battleMessage = document.getElementById('battle-message');
+  const battleMessageText = battleMessage?.querySelector('p');
+  const battleMessageButton = battleMessage?.querySelector('button');
   const completeMessage = document.getElementById('complete-message');
   const completeEnemyImg = completeMessage?.querySelector('.enemy-image');
   const summaryAccuracyValue = completeMessage?.querySelector('.summary-accuracy');
@@ -51,22 +49,6 @@ document.addEventListener('DOMContentLoaded', () => {
   let totalAnswers = 0;
   const battleStart = Date.now();
   let battleTimerInterval = null;
-
-  if (testButton) {
-    testButton.addEventListener('click', () => {
-      streak = Math.min(STREAK_GOAL - 1, 4);
-      streakMaxed = false;
-      updateStreak();
-    });
-  }
-
-  if (killButton) {
-    killButton.addEventListener('click', () => {
-      monster.damage = monster.health;
-      updateHealthBars();
-      endBattle(true);
-    });
-  }
 
   const hero = { attack: 1, health: 5, gems: 0, damage: 0, name: 'Hero' };
   const monster = { attack: 1, health: 5, damage: 0, name: 'Monster' };
@@ -376,9 +358,6 @@ document.addEventListener('DOMContentLoaded', () => {
       }, 2000);
     }
   });
-
-
-
   function endBattle(win) {
     stopBattleTimer();
     updateAccuracyDisplays();
@@ -393,18 +372,20 @@ document.addEventListener('DOMContentLoaded', () => {
       }
       completeMessage?.classList.add('show');
     } else {
-      levelText.textContent = 'you lose';
-      levelMessage.classList.add('show');
+      if (battleMessageText) {
+        battleMessageText.textContent = 'you lose';
+      }
+      battleMessage?.classList.add('show');
     }
   }
 
-  levelButton.addEventListener('click', () => {
+  battleMessageButton?.addEventListener('click', () => {
     window.location.reload();
   });
 
   if (nextMissionBtn) {
     nextMissionBtn.addEventListener('click', () => {
-      window.location.href = '../html/level.html';
+      window.location.href = '../html/battle-intro.html';
     });
   }
 

--- a/js/index.js
+++ b/js/index.js
@@ -1,39 +1,39 @@
 const initLandingInteractions = () => {
   const messageCard = document.querySelector('.message-card');
-  const levelOverlay = document.getElementById('level-overlay');
-  const battleButton = levelOverlay?.querySelector('.battle-btn');
+  const battleOverlay = document.getElementById('battle-overlay');
+  const battleButton = battleOverlay?.querySelector('.battle-btn');
   const messageTitle = messageCard?.querySelector('.message-title');
   const messageSubtitle = messageCard?.querySelector('.message-subtitle');
   const messageEnemy = messageCard?.querySelector('.message-enemy');
-  const overlayMath = levelOverlay?.querySelector('.math-type');
-  const overlayEnemy = levelOverlay?.querySelector('.enemy-image');
-  const overlayBattleTitle = levelOverlay?.querySelector('.battle-title');
-  const overlayAccuracy = levelOverlay?.querySelector('.accuracy-value');
-  const overlayTime = levelOverlay?.querySelector('.time-value');
+  const overlayMath = battleOverlay?.querySelector('.math-type');
+  const overlayEnemy = battleOverlay?.querySelector('.enemy-image');
+  const overlayBattleTitle = battleOverlay?.querySelector('.battle-title');
+  const overlayAccuracy = battleOverlay?.querySelector('.accuracy-value');
+  const overlayTime = battleOverlay?.querySelector('.time-value');
 
-  if (!messageCard || !levelOverlay) {
+  if (!messageCard || !battleOverlay) {
     return;
   }
 
   const defaultTabIndex = messageCard.getAttribute('tabindex') ?? '0';
-  let levelOverlayActivationTimeout;
+  let battleOverlayActivationTimeout;
   let messageCardReturnTimeout;
   let battleButtonFocusTimeout;
   const MESSAGE_CARD_EXIT_DURATION = 600;
-  const LEVEL_OVERLAY_FOCUS_DELAY = 400;
+  const BATTLE_OVERLAY_FOCUS_DELAY = 400;
   const MESSAGE_CARD_FOCUS_DELAY = MESSAGE_CARD_EXIT_DURATION;
 
-  const loadLevelPreview = async () => {
+  const loadBattlePreview = async () => {
     try {
       const response = await fetch('data/levels.json');
       const data = await response.json();
-      const [firstLevel] = data.levels ?? [];
+      const [firstBattle] = data.levels ?? [];
 
-      if (!firstLevel) {
+      if (!firstBattle) {
         return;
       }
 
-      const { id, math, enemySprite } = firstLevel;
+      const { id, math, enemySprite } = firstBattle;
       const enemyPath = typeof enemySprite === 'string' ? `images/${enemySprite}` : '';
 
       if (messageTitle && typeof math === 'string') {
@@ -68,22 +68,22 @@ const initLandingInteractions = () => {
         overlayTime.textContent = '0';
       }
     } catch (error) {
-      console.error('Failed to load level preview', error);
+      console.error('Failed to load battle preview', error);
     }
   };
 
-  loadLevelPreview();
+  loadBattlePreview();
 
   const openOverlay = () => {
     if (
-      document.body.classList.contains('level-open') ||
+      document.body.classList.contains('battle-overlay-open') ||
       document.body.classList.contains('message-exiting') ||
       messageCard.classList.contains('message-card--animating')
     ) {
       return;
     }
 
-    window.clearTimeout(levelOverlayActivationTimeout);
+    window.clearTimeout(battleOverlayActivationTimeout);
     window.clearTimeout(messageCardReturnTimeout);
     window.clearTimeout(battleButtonFocusTimeout);
 
@@ -92,9 +92,9 @@ const initLandingInteractions = () => {
     document.body.classList.add('message-exiting');
     messageCard.setAttribute('aria-expanded', 'true');
 
-    levelOverlayActivationTimeout = window.setTimeout(() => {
-      document.body.classList.add('level-open');
-      levelOverlay.setAttribute('aria-hidden', 'false');
+    battleOverlayActivationTimeout = window.setTimeout(() => {
+      document.body.classList.add('battle-overlay-open');
+      battleOverlay.setAttribute('aria-hidden', 'false');
       messageCard.classList.add('message-card--hidden');
       messageCard.classList.remove('message-card--animating');
       messageCard.setAttribute('aria-hidden', 'true');
@@ -102,21 +102,21 @@ const initLandingInteractions = () => {
 
       battleButtonFocusTimeout = window.setTimeout(() => {
         battleButton?.focus({ preventScroll: true });
-      }, LEVEL_OVERLAY_FOCUS_DELAY);
+      }, BATTLE_OVERLAY_FOCUS_DELAY);
     }, MESSAGE_CARD_EXIT_DURATION);
   };
 
   const closeOverlay = () => {
-    if (!document.body.classList.contains('level-open')) {
+    if (!document.body.classList.contains('battle-overlay-open')) {
       return;
     }
 
-    window.clearTimeout(levelOverlayActivationTimeout);
+    window.clearTimeout(battleOverlayActivationTimeout);
     window.clearTimeout(messageCardReturnTimeout);
     window.clearTimeout(battleButtonFocusTimeout);
 
-    document.body.classList.remove('level-open');
-    levelOverlay.setAttribute('aria-hidden', 'true');
+    document.body.classList.remove('battle-overlay-open');
+    battleOverlay.setAttribute('aria-hidden', 'true');
     messageCard.classList.remove('message-card--hidden');
     messageCard.classList.add('message-card--animating');
     messageCard.classList.add('message-card--no-delay');
@@ -143,8 +143,8 @@ const initLandingInteractions = () => {
     }
   });
 
-  levelOverlay.addEventListener('click', (event) => {
-    if (event.target === levelOverlay) {
+  battleOverlay.addEventListener('click', (event) => {
+    if (event.target === battleOverlay) {
       closeOverlay();
     }
   });


### PR DESCRIPTION
## Summary
- introduce a shared battle card stylesheet so the battle completion modal inherits the same styling as the intro card
- rename level overlay, markup, and scripts to battle terminology for consistent language across the app
- clean redundant CSS and JavaScript, removing debug buttons and duplicate button styles while updating navigation to the new battle intro page

## Testing
- No tests were run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68c8bd59fffc8329abc4e7a0588f5f1e