### PR TITLE
Enforce landing entry and add battle test controls

### DIFF
--- a/css/battle-card.css
+++ b/css/battle-card.css
@@ -41,9 +41,9 @@
 
 .battle-card .battle-stats {
   width: 100%;
-  display: flex;
-  justify-content: space-between;
-  gap: 16px;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px 16px;
   padding: 16px 20px;
   background: rgba(0, 48, 120, 0.08);
   border-radius: 12px;

--- a/css/question.css
+++ b/css/question.css
@@ -66,6 +66,40 @@
   color: #272B34;
 }
 
+#question .dev-controls {
+  width: 100%;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  justify-content: flex-start;
+}
+
+#question .dev-controls .dev-btn {
+  width: auto;
+  height: auto;
+  flex: 1 1 160px;
+  padding: 12px 16px;
+  background: #F1F5FF;
+  color: #1D2433;
+  border: 2px dashed #006AFF;
+  border-radius: 8px;
+  font-size: 16px;
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+#question .dev-controls .dev-btn:hover {
+  background: #E3ECFF;
+  color: #0040AA;
+  border-color: #0040AA;
+}
+
+#question .dev-controls .dev-btn:focus-visible {
+  outline: 3px solid #00A1FF;
+  outline-offset: 2px;
+}
+
 #question .top-bar {
   width: 100%;
   align-items: center;

--- a/html/battle.html
+++ b/html/battle.html
@@ -70,6 +70,14 @@
             </div>
           </div>
         </div>
+        <div class="dev-controls" role="group" aria-label="Battle test controls">
+          <button type="button" class="dev-btn" data-dev-set-streak>
+            Set Streak 4
+          </button>
+          <button type="button" class="dev-btn" data-dev-end-battle>
+            End Battle
+          </button>
+        </div>
         <p class="question-text"></p>
         <div class="choices"></div>
         <button type="button">Submit</button>

--- a/js/battle-intro.js
+++ b/js/battle-intro.js
@@ -1,4 +1,24 @@
+const LANDING_VISITED_KEY = 'reefRangersVisitedLanding';
+
+const hasVisitedLanding = () => {
+  try {
+    return sessionStorage.getItem(LANDING_VISITED_KEY) === 'true';
+  } catch (error) {
+    console.warn('Session storage is not available.', error);
+    return true;
+  }
+};
+
+const landingVisited = hasVisitedLanding();
+
+if (!landingVisited) {
+  window.location.replace('../index.html');
+}
+
 document.addEventListener('DOMContentLoaded', async () => {
+  if (!landingVisited) {
+    return;
+  }
   const mathType = document.querySelector('.math-type');
   const battleTitle = document.querySelector('.battle-title');
   const enemyImage = document.querySelector('.enemy-image');

--- a/js/battle.js
+++ b/js/battle.js
@@ -1,4 +1,24 @@
+const LANDING_VISITED_KEY = 'reefRangersVisitedLanding';
+
+const hasVisitedLanding = () => {
+  try {
+    return sessionStorage.getItem(LANDING_VISITED_KEY) === 'true';
+  } catch (error) {
+    console.warn('Session storage is not available.', error);
+    return true;
+  }
+};
+
+const landingVisited = hasVisitedLanding();
+
+if (!landingVisited) {
+  window.location.replace('../index.html');
+}
+
 document.addEventListener('DOMContentLoaded', () => {
+  if (!landingVisited) {
+    return;
+  }
   const monsterImg = document.getElementById('battle-monster');
   const heroImg = document.getElementById('battle-shellfin');
   const monsterHpFill = document.querySelector('#monster-stats .hp-fill');
@@ -18,6 +38,8 @@ document.addEventListener('DOMContentLoaded', () => {
   const streakIcon = questionBox.querySelector('.streak-icon');
   const bannerAccuracyValue = document.querySelector('[data-banner-accuracy]');
   const bannerTimeValue = document.querySelector('[data-banner-time]');
+  const setStreakButton = document.querySelector('[data-dev-set-streak]');
+  const endBattleButton = document.querySelector('[data-dev-end-battle]');
   const heroAttackVal = heroStats.querySelector('.attack .value');
   const heroHealthVal = heroStats.querySelector('.health .value');
   const heroAttackInc = heroStats.querySelector('.attack .increase');
@@ -49,6 +71,7 @@ document.addEventListener('DOMContentLoaded', () => {
   let totalAnswers = 0;
   const battleStart = Date.now();
   let battleTimerInterval = null;
+  let battleEnded = false;
 
   const hero = { attack: 1, health: 5, gems: 0, damage: 0, name: 'Hero' };
   const monster = { attack: 1, health: 5, damage: 0, name: 'Monster' };
@@ -144,6 +167,9 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   function showQuestion() {
+    if (battleEnded) {
+      return;
+    }
     const q = questions[currentQuestion];
     if (!q) return;
     questionText.textContent = q.question || q.q || '';
@@ -234,12 +260,18 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   function heroAttack() {
+    if (battleEnded) {
+      return;
+    }
     heroImg.classList.add('attack');
     const handler = (e) => {
       if (e.animationName !== 'hero-attack') return;
       heroImg.classList.remove('attack');
       heroImg.removeEventListener('animationend', handler);
       setTimeout(() => {
+        if (battleEnded) {
+          return;
+        }
         monster.damage += hero.attack;
         updateHealthBars();
         if (streakMaxed) {
@@ -249,6 +281,9 @@ document.addEventListener('DOMContentLoaded', () => {
           updateStreak();
         }
         setTimeout(() => {
+          if (battleEnded) {
+            return;
+          }
           if (monster.damage >= monster.health) {
             endBattle(true);
           } else {
@@ -262,16 +297,28 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   function monsterAttack() {
+    if (battleEnded) {
+      return;
+    }
     setTimeout(() => {
+      if (battleEnded) {
+        return;
+      }
       monsterImg.classList.add('attack');
       const handler = (e) => {
         if (e.animationName !== 'monster-attack') return;
         monsterImg.classList.remove('attack');
         monsterImg.removeEventListener('animationend', handler);
         setTimeout(() => {
+          if (battleEnded) {
+            return;
+          }
           hero.damage += monster.attack;
           updateHealthBars();
           setTimeout(() => {
+            if (battleEnded) {
+              return;
+            }
             if (hero.damage >= hero.health) {
               endBattle(false);
             } else {
@@ -285,7 +332,30 @@ document.addEventListener('DOMContentLoaded', () => {
     }, 300);
   }
 
+  setStreakButton?.addEventListener('click', () => {
+    if (battleEnded) {
+      return;
+    }
+    const targetStreak = Math.max(0, STREAK_GOAL - 1);
+    streak = targetStreak;
+    streakMaxed = false;
+    updateStreak();
+  });
+
+  endBattleButton?.addEventListener('click', () => {
+    if (battleEnded) {
+      return;
+    }
+    document.dispatchEvent(new Event('close-question'));
+    window.setTimeout(() => {
+      endBattle(true);
+    }, 0);
+  });
+
   document.addEventListener('answer-submitted', (e) => {
+    if (battleEnded) {
+      return;
+    }
     const correct = e.detail.correct;
     totalAnswers++;
     if (correct) correctAnswers++;
@@ -359,6 +429,10 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   });
   function endBattle(win) {
+    if (battleEnded) {
+      return;
+    }
+    battleEnded = true;
     stopBattleTimer();
     updateAccuracyDisplays();
     if (win) {
@@ -390,6 +464,7 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   function initBattle() {
+    battleEnded = false;
     loadData();
     updateStreak();
     updateAccuracyDisplays();

--- a/js/index.js
+++ b/js/index.js
@@ -1,4 +1,15 @@
+const LANDING_VISITED_KEY = 'reefRangersVisitedLanding';
+
+const markLandingVisited = () => {
+  try {
+    sessionStorage.setItem(LANDING_VISITED_KEY, 'true');
+  } catch (error) {
+    console.warn('Session storage is not available.', error);
+  }
+};
+
 const initLandingInteractions = () => {
+  markLandingVisited();
   const messageCard = document.querySelector('.message-card');
   const battleOverlay = document.getElementById('battle-overlay');
   const battleButton = battleOverlay?.querySelector('.battle-btn');


### PR DESCRIPTION
## Summary
- mark the landing page visit in session storage and gate battle-related pages so index.html loads first
- restore battle test controls and style them while updating overlay stats to a two-column layout
- guard battle flow with a battle-ended flag so the new controls remain stable

## Testing
- Not run (static site changes)


------
https://chatgpt.com/codex/tasks/task_e_68c8c911d11883299858d3166c226625