### PR TITLE
Add Battle Goals headings to battle cards

### DIFF
--- a/css/battle-card.css
+++ b/css/battle-card.css
@@ -19,6 +19,13 @@
   gap: 6px;
 }
 
+.battle-card .battle-goals-title {
+  margin: 0;
+  font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
+  font-size: 20px;
+  color: #272b34;
+}
+
 .battle-card .math-type {
   margin: 0;
   font-size: 20px;

--- a/html/battle.html
+++ b/html/battle.html
@@ -95,6 +95,7 @@
           src="../images/battle/monster_battle.png"
           alt="Enemy defeated in battle"
         />
+        <p class="battle-goals-title">Battle Goals</p>
         <div class="battle-stats">
           <div class="battle-stat">
             <span class="stat-label">Accuracy</span>

--- a/index.html
+++ b/index.html
@@ -46,7 +46,6 @@
         data-battle-enemy
       />
     </aside>
-    <p>Battle Goals</p>
     <div id="battle-overlay" class="battle-overlay" aria-hidden="true">
       <div
         class="battle-card battle-overlay-card"
@@ -64,6 +63,7 @@
           src="images/battle/monster_battle.png"
           alt="Enemy monster ready for battle"
         />
+        <p class="battle-goals-title">Battle Goals</p>
         <div id="battle-overlay-stats" class="battle-stats" aria-live="polite">
           <div class="battle-stat">
             <span class="stat-label">Accuracy</span>


### PR DESCRIPTION
## Summary
- add Battle Goals heading above battle stats on the battle overlay card
- mirror the Battle Goals heading on the battle complete card
- style the new heading with Arial Rounded MT Bold at 20px in #272B34

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68c9ac36f1f0832981d8572fccf57063