### PR TITLE
Allow battle page to detect landing visits across tabs

### DIFF
--- a/js/battle.js
+++ b/js/battle.js
@@ -1,12 +1,48 @@
 const LANDING_VISITED_KEY = 'reefRangersVisitedLanding';
+const VISITED_VALUE = 'true';
+
+const readVisitedFlag = (storage, label) => {
+  if (!storage) {
+    return null;
+  }
+  try {
+    return storage.getItem(LANDING_VISITED_KEY) === VISITED_VALUE;
+  } catch (error) {
+    console.warn(`${label} storage is not available.`, error);
+    return null;
+  }
+};
+
+const setVisitedFlag = (storage, label) => {
+  if (!storage) {
+    return;
+  }
+  try {
+    storage.setItem(LANDING_VISITED_KEY, VISITED_VALUE);
+  } catch (error) {
+    console.warn(`${label} storage is not available.`, error);
+  }
+};
 
 const hasVisitedLanding = () => {
-  try {
-    return sessionStorage.getItem(LANDING_VISITED_KEY) === 'true';
-  } catch (error) {
-    console.warn('Session storage is not available.', error);
+  const sessionVisited = readVisitedFlag(sessionStorage, 'Session');
+  if (sessionVisited === true) {
     return true;
   }
+  if (sessionVisited === null) {
+    return true;
+  }
+
+  const localVisited = readVisitedFlag(localStorage, 'Local');
+  if (localVisited === true) {
+    setVisitedFlag(sessionStorage, 'Session');
+    return true;
+  }
+  if (localVisited === null) {
+    return true;
+  }
+
+  return false;
 };
 
 const landingVisited = hasVisitedLanding();

--- a/js/index.js
+++ b/js/index.js
@@ -1,11 +1,21 @@
 const LANDING_VISITED_KEY = 'reefRangersVisitedLanding';
 
-const markLandingVisited = () => {
-  try {
-    sessionStorage.setItem(LANDING_VISITED_KEY, 'true');
-  } catch (error) {
-    console.warn('Session storage is not available.', error);
+const VISITED_VALUE = 'true';
+
+const setVisitedFlag = (storage, label) => {
+  if (!storage) {
+    return;
   }
+  try {
+    storage.setItem(LANDING_VISITED_KEY, VISITED_VALUE);
+  } catch (error) {
+    console.warn(`${label} storage is not available.`, error);
+  }
+};
+
+const markLandingVisited = () => {
+  setVisitedFlag(sessionStorage, 'Session');
+  setVisitedFlag(localStorage, 'Local');
 };
 
 const randomizeBubbleTimings = () => {


### PR DESCRIPTION
## Summary
- write a shared helper on the landing page so the visited flag is stored in both session and local storage
- update the battle page guard to read the local-storage fallback and synchronise it into session storage so opening the battle in a new tab no longer bounces back to the landing screen

## Testing
- Manual verification using a local `python3 -m http.server 8000` instance and Playwright script to ensure a new tab stays on the battle page

------
https://chatgpt.com/codex/tasks/task_e_68c9d19deeac8329844d265aea1b5829