### PR TITLE
Implement battle countdown and goal indicators

### DIFF
--- a/css/battle-card.css
+++ b/css/battle-card.css
@@ -137,6 +137,26 @@
   font-family: 'Arial Rounded MT Bold', 'Arial Rounded', Arial, sans-serif;
 }
 
+.battle-card .stat-value {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.battle-card .stat-value.goal-result--met {
+  color: #00B600;
+}
+
+.battle-card .stat-value.goal-result--missed {
+  color: #E20000;
+}
+
+.battle-card .stat-value .goal-result-icon {
+  width: 24px;
+  height: 24px;
+  flex-shrink: 0;
+}
+
 .btn-primary {
   width: 100%;
   height: 64px;

--- a/html/battle.html
+++ b/html/battle.html
@@ -95,16 +95,20 @@
         />
         <p class="battle-goals-title">Battle Goals</p>
         <div class="battle-stats">
-          <div class="battle-stat">
+          <div class="battle-stat" data-goal="accuracy">
             <span class="stat-label">Accuracy</span>
-            <span class="stat-value summary-accuracy">0%</span>
+            <span class="stat-value summary-accuracy">
+              <span class="stat-value-text">0%</span>
+            </span>
           </div>
-          <div class="battle-stat">
+          <div class="battle-stat" data-goal="time">
             <span class="stat-label">Time</span>
-            <span class="stat-value summary-time">0s</span>
+            <span class="stat-value summary-time">
+              <span class="stat-value-text">0s</span>
+            </span>
           </div>
         </div>
-        <button type="button" class="btn-primary next-mission-btn">Next Mission</button>
+        <button type="button" class="btn-primary next-mission-btn" data-action="next">Next Mission</button>
       </section>
     </div>
     <div id="battle-message">


### PR DESCRIPTION
## Summary
- count down the battle timer from the configured goal and end the battle on timeout while updating the completion overlay copy and actions
- show accuracy and time goal results with coloured indicators and icons, including new styling for the battle completion card
- persist the player’s battle level in local storage and load it on both the battle and landing pages so wins advance the next mission

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68c9d6df0434832983060d51979eb32b