### PR TITLE
Fix battle loader constant collision

### DIFF
--- a/js/loader.js
+++ b/js/loader.js
@@ -1,4 +1,4 @@
-const PROGRESS_STORAGE_KEY = 'reefRangersProgress';
+const STORAGE_KEY_PROGRESS = 'reefRangersProgress';
 
 const readStoredProgress = () => {
   try {
@@ -6,7 +6,7 @@ const readStoredProgress = () => {
     if (!storage) {
       return null;
     }
-    const raw = storage.getItem(PROGRESS_STORAGE_KEY);
+    const raw = storage.getItem(STORAGE_KEY_PROGRESS);
     if (!raw) {
       return null;
     }


### PR DESCRIPTION
## Summary
- rename the loader progress storage constant so it no longer clashes with battle.js when both scripts run on the battle page
- keep the shared storage key value unchanged so persisted progress continues to load correctly

## Testing
- browser_container.run_playwright_script (battle page smoke test)


------
https://chatgpt.com/codex/tasks/task_e_68c9f5cf6c80832994f57194856e017d